### PR TITLE
BiophysHelper. Analogue of MorphHelper.

### DIFF
--- a/bluepysnap/biophys.py
+++ b/bluepysnap/biophys.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2019, EPFL/Blue Brain Project
+
+# This file is part of BlueBrain SNAP library <https://github.com/BlueBrain/snap>
+
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 3.0 as published
+# by the Free Software Foundation.
+
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Biophys access."""
+
+import os
+
+
+class BiophysHelper(object):
+    """Collection of morphology-related methods."""
+
+    def __init__(self, biophys_dir, nodes):
+        """Initializes a BiophysHelper object from a directory path and a NodePopulation object.
+
+        Args:
+            biophys_dir (str): Path to the directory containing the node morphologies.
+            nodes (NodePopulation): NodePopulation object used to query the nodes.
+
+        Returns:
+            BiophysHelper: A BiophysHelper object.
+        """
+        self._biophys_dir = biophys_dir
+        self._nodes = nodes
+
+    def get_filepath(self, node_id):
+        """Return path to biophys file corresponding to `node_id`."""
+        template = self._nodes.get(node_id, 'model_template')
+        assert ':' in template
+        schema, resource = template.split(':', 1)
+        if os.path.isabs(resource):
+            return resource
+        return os.path.join(self._biophys_dir, resource)

--- a/bluepysnap/nodes.py
+++ b/bluepysnap/nodes.py
@@ -372,3 +372,12 @@ class NodePopulation(object):
             self._circuit.config['components']['morphologies_dir'],
             self
         )
+
+    @cached_property
+    def biophys(self):
+        """Access to node morphologies."""
+        from bluepysnap.biophys import BiophysHelper
+        return BiophysHelper(
+            self._circuit.config['components']['biophysical_neuron_models_dir'],
+            self
+        )


### PR DESCRIPTION
Don't merge. This PR is too early to merge. The spec on this is too vague. Problems:
- In `schema`:`resource` of `model_template` does `schema` defines the file extension of `resource`? Not clear. Allan Institute does not omit the file extension in `resource`. Seems we can follow the same way.
- `resource` can be a url, an absolute path or a relative path. If it is a url then how `schema` defines its file extension? How the user can determine which `schema` he is dealing with in case of the url?
- It is not clear what directory used in `resource` for files other than `.nml` because `biophysical_neuron_models_dir` is for `.nml` according to spec. There is also `point_neuron_models_dir` but it is for point neurons only. In case `schema` is `nrn` then node can be compartmental or a point one. What directory use in this case?
- What should be returned when node is not biophysical? For example it is virtual then exception?
- `model_processing` field that somehow should affect biophys construction. How it should be reflected for `BiophysHelper`?

The resolution is to postpone BiophysHelper.
Also I would suggest to drop MorphHelper because currently it would be giving false results for nodes other than biophysical.