### PR TITLE
Add Standalone objects for node and edges

### DIFF
--- a/bluepysnap/edges.py
+++ b/bluepysnap/edges.py
@@ -483,7 +483,7 @@ class StandaloneEdgeStorage(EdgeStorage):
         if not utils.is_path_like(h5_filepath):
             raise BluepySnapError("h5_filepath must be a path compatible object")
         config = {'edges_file': h5_filepath, 'edge_types_file': csv_file}
-        super().__init__(config, None)
+        super(StandaloneEdgeStorage, self).__init__(config, None)
 
     @property
     def circuit(self):
@@ -528,7 +528,7 @@ class StandaloneEdgePopulation(EdgePopulation):
         if not utils.is_path_like(h5_filepath):
             raise BluepySnapError("h5_filepath must be a path compatible object")
         storage = StandaloneEdgeStorage(h5_filepath, csv_file=csv_file)
-        super().__init__(storage, population_name)
+        super(StandaloneEdgePopulation, self).__init__(storage, population_name)
 
     @staticmethod
     def _resolve_node_ids(nodes, group):

--- a/bluepysnap/nodes.py
+++ b/bluepysnap/nodes.py
@@ -476,7 +476,7 @@ class StandaloneNodeStorage(NodeStorage):
             config['node_sets_file'] = node_sets_file
         self._node_sets_file = node_sets_file
         self._morphologies_dir = morphologies_dir
-        super().__init__(config, None)
+        super(StandaloneNodeStorage, self).__init__(config, None)
 
     @property
     def circuit(self):
@@ -528,7 +528,7 @@ class StandaloneNodePopulation(NodePopulation):
         storage = StandaloneNodeStorage(h5_filepath, csv_file=csv_file,
                                         node_sets_file=node_sets_file)
         self._morphologies_dir = morphologies_dir
-        super().__init__(storage, population_name)
+        super(StandaloneNodePopulation, self).__init__(storage, population_name)
 
     @cached_property
     def morph(self):

--- a/bluepysnap/utils.py
+++ b/bluepysnap/utils.py
@@ -22,6 +22,7 @@ import json
 
 import numpy as np
 import six
+from pathlib2 import Path
 
 from bluepysnap.exceptions import BluepySnapError
 from bluepysnap.sonata_constants import DYNAMICS_PREFIX
@@ -49,6 +50,14 @@ def ensure_list(v):
 def add_dynamic_prefix(properties):
     """Add the dynamic prefix to a list of properties."""
     return [DYNAMICS_PREFIX + name for name in list(properties)]
+
+
+def is_path(path):
+    try:
+        Path(path)
+        return True
+    except TypeError:
+        return False
 
 
 def euler2mat(az, ay, ax):

--- a/bluepysnap/utils.py
+++ b/bluepysnap/utils.py
@@ -52,7 +52,11 @@ def add_dynamic_prefix(properties):
     return [DYNAMICS_PREFIX + name for name in list(properties)]
 
 
-def is_path(path):
+def is_path_like(path):
+    """Returns True if type(path) could be a type used for a path.
+
+    This function does not check the validity of the path itself just the correct type.
+    """
     try:
         Path(path)
         return True
@@ -104,6 +108,7 @@ def quaternion2mat(aqw, aqx, aqy, aqz):
     See Also:
         https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
     """
+
     def normalize_quaternions(qs):
         """Normalize a bunch of quaternions along axis==1.
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -468,11 +468,11 @@ class TestStandaloneNodePopulation(TestNodePopulation):
     def test_morph(self):
         from bluepysnap.morph import MorphHelper
         tested = self.create_population(str(TEST_DATA_DIR / 'nodes.h5'),
-                               "default",
-                               morphologies_dir="morphologies")
+                                        "default",
+                                        morphologies_dir="morphologies")
         assert isinstance(tested.morph, MorphHelper)
 
         tested = self.create_population(str(TEST_DATA_DIR / 'nodes.h5'), "default")
-        
+
         with pytest.raises(BluepySnapError):
             tested.morph, MorphHelper

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
+import pathlib2
 
 import bluepysnap.utils as test_module
 from bluepysnap.sonata_constants import DYNAMICS_PREFIX
@@ -31,6 +32,15 @@ def test_ensure_list():
 
 def test_add_dynamic_prefix():
     assert test_module.add_dynamic_prefix(["a", "b"]) == [DYNAMICS_PREFIX+"a", DYNAMICS_PREFIX+"b"]
+
+
+def test_is_path_like():
+    assert test_module.is_path_like(pathlib2.Path("."))
+    assert test_module.is_path_like(".")
+
+    assert not test_module.is_path_like(1)
+    assert not test_module.is_path_like((1, 2))
+    assert not test_module.is_path_like({1:1})
 
 
 def test_euler2mat():


### PR DESCRIPTION
This appears to be very handy when someone wants to explore a standalone
file without a circuit config or the proper link to the node files for edges.