### PR TITLE
fix report query for empty arrays or tuple

### DIFF
--- a/bluepysnap/frame_report.py
+++ b/bluepysnap/frame_report.py
@@ -19,6 +19,7 @@ import logging
 
 from cached_property import cached_property
 from pathlib2 import Path
+import numpy as np
 import pandas as pd
 from libsonata import ElementReportReader
 
@@ -212,7 +213,7 @@ class PopulationCompartmentReport(PopulationFrameReport):
 
     def _resolve(self, group):
         """Transform a group into a node_id array."""
-        if group == []:
+        if isinstance(group, (np.ndarray, list, tuple)) and len(group) == 0:
             return fix_libsonata_empty_list()
         return self.nodes.ids(group=group)
 

--- a/bluepysnap/spike_report.py
+++ b/bluepysnap/spike_report.py
@@ -85,7 +85,7 @@ class PopulationSpikeReport(object):
 
     def _resolve_nodes(self, group):
         """Transform a node group into a node_id array."""
-        if group == []:
+        if isinstance(group, (np.ndarray, list, tuple)) and len(group) == 0:
             return fix_libsonata_empty_list()
         return self.nodes.ids(group=group)
 

--- a/tests/test_frame_report.py
+++ b/tests/test_frame_report.py
@@ -143,6 +143,8 @@ class TestPopulationCompartmentReport:
         pdt.assert_frame_equal(self.test_obj.get(), self.df)
 
         pdt.assert_frame_equal(self.test_obj.get([]),  pd.DataFrame())
+        pdt.assert_frame_equal(self.test_obj.get(np.array([])),  pd.DataFrame())
+        pdt.assert_frame_equal(self.test_obj.get(()),  pd.DataFrame())
 
         pdt.assert_frame_equal(self.test_obj.get(2), self.df.loc[:, [2]])
 

--- a/tests/test_spike_report.py
+++ b/tests/test_spike_report.py
@@ -106,6 +106,8 @@ class TestPopulationSpikeReport:
         pdt.assert_series_equal(self.test_obj.get(),
                                 _create_series([2, 0, 1, 2, 0], [0.1, 0.2, 0.3, 0.7, 1.3]))
         pdt.assert_series_equal(self.test_obj.get([]), _create_series([], []))
+        pdt.assert_series_equal(self.test_obj.get(np.array([])), _create_series([], []))
+        pdt.assert_series_equal(self.test_obj.get(()), _create_series([], []))
         npt.assert_allclose(self.test_obj.get(2), np.array([0.1, 0.7]))
         npt.assert_allclose(self.test_obj.get(0, t_start=1.), [1.3])
         npt.assert_allclose(self.test_obj.get(0, t_stop=1.), [0.2])


### PR DESCRIPTION
fix for report .get function with empty tuple and array