### PR TITLE
Fix circuit validation for missing edge_group_id/index

### DIFF
--- a/bluepysnap/circuit_validation.py
+++ b/bluepysnap/circuit_validation.py
@@ -169,9 +169,14 @@ def _find_nodes_population(node_population_name, nodes):
     return None
 
 
-def _get_group_name(group):
-    """Gets group name of h5 group."""
-    return Path(group.parent.name).name
+def _get_group_name(group, parents=1):
+    """Gets group name of h5 group.
+
+    Args:
+        group (h5py.Group): nodes group in nodes .h5 file
+        parents (int): number of extra parents needed
+    """
+    return Path(*Path(group.name).parts[-(parents+1):])
 
 
 def _get_h5_data(h5, path):
@@ -408,6 +413,52 @@ def _check_edges_indices(population):
     return errors
 
 
+def _get_edge_population_groups(population):
+    """Get groups from a edge population."""
+    return [name for name in population
+            if name != "indices" and isinstance(population[name], h5py.Group)]
+
+
+def _check_edge_group_id(population):
+    errors = []
+    groups = np.array(_get_edge_population_groups(population))
+    group_datasets = ["edge_group_id",  "edge_group_index"]
+    missing_datasets = set(group_datasets) - set(population)
+    population_name = _get_group_name(population, parents=0)
+    if len(groups) > 1:
+        errors.append(BbpError(Error.WARNING, 'Population {} of {} have multiple groups. '
+                                              'Cannot be read via bluepysnap or libsonata'.
+                               format(population_name, population.file.filename, missing_datasets)))
+    if len(missing_datasets) == 2 and len(groups) == 1:
+        # no "edge_group_id", "edge_group_index" but only one group
+        return errors
+    elif len(missing_datasets) == 1:
+        return errors + [fatal('Population {} of {} misses dataset {}'.
+                                   format(population_name, population.file.filename, missing_datasets))]
+
+    edge_group_ids = population["edge_group_id"][:]
+    edge_group_index = population["edge_group_index"][:]
+
+    if len(edge_group_ids) != len(edge_group_index):
+        return errors + [fatal('Population {} of {} "edge_group_ids" and "edge_'
+                               'group_index" of different sizes'.
+                               format(population_name, population.file.filename))]
+
+    group_ids = np.unique(edge_group_ids)
+    missing_groups = set(group_ids) - set(groups.astype(int))
+
+    if missing_groups:
+        return errors + [fatal('Population {} of {} misses group(s): {}'.
+                               format(population_name, population.file.filename, missing_groups))]
+    for group_id in group_ids:
+        group = population[str(group_id)]
+        max_edge_id = edge_group_index[edge_group_ids == int(group_id)].max()
+        if group[list(group)[0]].shape[0] < max_edge_id:
+            errors.append(fatal('Group {} in file {} should have ids up to {}'.
+                                format(_get_group_name(group, parents=1), population.file.filename, max_edge_id)))
+    return errors
+
+
 def _check_edges_population(edges_dict, nodes):
     """Validates edges population.
 
@@ -418,8 +469,7 @@ def _check_edges_population(edges_dict, nodes):
     Returns:
         list: List of errors, empty if no errors
     """
-    POPULATION_DATASET_NAMES = [
-        'edge_type_id', 'source_node_id', 'target_node_id', 'edge_group_id', 'edge_group_index']
+
     errors = []
     edges_file = edges_dict.get('edges_file')
     with h5py.File(edges_file, 'r') as h5f:
@@ -427,24 +477,36 @@ def _check_edges_population(edges_dict, nodes):
         if not edges or len(edges) == 0:
             errors.append(fatal('No "edges" in {}.'.format(edges_file)))
             return errors
+
         for population_name in edges:
+            required_datasets = ['edge_type_id', 'source_node_id', 'target_node_id']
+
             population_path = '/edges/' + population_name
             population = h5f[population_path]
+            groups = _get_edge_population_groups(population)
+
+            if len(groups) != 1:
+                required_datasets = required_datasets + ['edge_group_id', 'edge_group_index']
+
             children_names = set(population.keys())
-            missing_datasets = sorted(set(POPULATION_DATASET_NAMES) - children_names)
+            missing_datasets = sorted(set(required_datasets) - children_names)
             if missing_datasets:
                 errors.append(fatal('Population {} of {} misses datasets {}'.
                                     format(population_name, edges_file, missing_datasets)))
                 return errors
-            for name in children_names - {'indices'}:
+
+            errors += _check_edge_group_id(population)
+            for name in groups:
                 if isinstance(population[name], h5py.Group):
                     errors += _check_edges_group_bbp(population[name])
+
             if 'source_node_id' in children_names:
                 errors += _check_edges_node_ids(population['source_node_id'], nodes)
             if 'target_node_id' in children_names:
                 errors += _check_edges_node_ids(population['target_node_id'], nodes)
             if 'indices' in children_names:
                 errors += _check_edges_indices(population)
+
     return errors
 
 

--- a/bluepysnap/circuit_validation.py
+++ b/bluepysnap/circuit_validation.py
@@ -425,8 +425,6 @@ def _check_edge_population_data(population, groups, nodes):
     # pylint: disable=too-many-locals,too-many-return-statements,too-many-branches
     errors = []
     population_name = _get_group_name(population)
-    if len(groups) == 0:
-        return errors
     if len(groups) > 1:
         errors.append(BbpError(Error.WARNING, 'Population {} of {} have multiple groups. '
                                               'Cannot be read via bluepysnap or libsonata'.
@@ -442,12 +440,15 @@ def _check_edge_population_data(population, groups, nodes):
     if missing_datasets:
         return errors + [fatal('Population {} of {} misses datasets {}'.
                                format(population_name, population.file.filename, missing_datasets))]
+    if len(groups) == 0:
+        return errors
+
+    # pure group part
     missing_group_datasets = set(group_datasets) - set(population)
     if len(missing_group_datasets) == 1:
         return errors + [fatal('Population {} of {} misses dataset {}'.
                                format(population_name, population.file.filename,
                                       missing_group_datasets))]
-
     if len(missing_group_datasets) == 2 and len(groups) == 1:
         # no "edge_group_id", "edge_group_index" and only one group --> can use implicit ids
         return errors

--- a/bluepysnap/circuit_validation.py
+++ b/bluepysnap/circuit_validation.py
@@ -432,7 +432,7 @@ def _check_edge_group_id(population):
                                               'Cannot be read via bluepysnap or libsonata'.
                                format(population_name, population.file.filename)))
     if len(missing_datasets) == 2 and len(groups) == 1:
-        # no "edge_group_id", "edge_group_index" but only one group
+        # no "edge_group_id", "edge_group_index" and only one group --> can use implicit ids
         return errors
     elif len(missing_datasets) == 1:
         return errors + [fatal('Population {} of {} misses dataset {}'.

--- a/bluepysnap/circuit_validation.py
+++ b/bluepysnap/circuit_validation.py
@@ -427,6 +427,8 @@ def _check_edge_group_id(population):
     group_datasets = ["edge_group_id", "edge_group_index"]
     missing_datasets = set(group_datasets) - set(population)
     population_name = _get_group_name(population)
+    if len(groups) == 0:
+        return errors
     if len(groups) > 1:
         errors.append(BbpError(Error.WARNING, 'Population {} of {} have multiple groups. '
                                               'Cannot be read via bluepysnap or libsonata'.
@@ -442,7 +444,7 @@ def _check_edge_group_id(population):
     edge_group_index = population["edge_group_index"][:]
 
     if len(edge_group_ids) != len(edge_group_index):
-        return errors + [fatal('Population {} of {} "edge_group_ids" and "edge_'
+        return errors + [fatal('Population {} of {} "edge_group_id" and "edge_'
                                'group_index" of different sizes'.
                                format(population_name, population.file.filename))]
 
@@ -487,7 +489,7 @@ def _check_edges_population(edges_dict, nodes):
             population = h5f[population_path]
             groups = _get_edge_population_groups(population)
 
-            if len(groups) != 1:
+            if len(groups) > 1:
                 required_datasets = required_datasets + ['edge_group_id', 'edge_group_index']
 
             children_names = set(population.keys())

--- a/tests/test_circuit_validation.py
+++ b/tests/test_circuit_validation.py
@@ -181,7 +181,7 @@ def test_no_required_node_group_datasets():
                 del h5f['nodes/default/0/' + ds]
         errors = test_module.validate(str(config_copy_path))
         assert errors == [Error(Error.FATAL,
-                                'Group default of {} misses required fields: {}'
+                                'Group default/0 of {} misses required fields: {}'
                                 .format(nodes_file, required_datasets))]
 
 
@@ -203,7 +203,7 @@ def test_no_required_bio_node_group_datasets():
                 del h5f['nodes/default/0/' + ds]
         errors = test_module.validate(str(config_copy_path))
         assert errors == [Error(Error.FATAL,
-                                'Group default of {} misses biophysical fields: {}'
+                                'Group default/0 of {} misses biophysical fields: {}'
                                 .format(nodes_file, required_datasets))]
 
 
@@ -216,7 +216,7 @@ def test_no_rotation_bio_node_group_datasets():
                 del h5f['nodes/default/0/' + ds]
         errors = test_module.validate(str(config_copy_path))
         assert errors == [Error(Error.WARNING,
-                                'Group default of {} has no rotation fields'.format(nodes_file))]
+                                'Group default/0 of {} has no rotation fields'.format(nodes_file))]
 
 
 def test_no_rotation_bbp_node_group_datasets():
@@ -229,8 +229,8 @@ def test_no_rotation_bbp_node_group_datasets():
             h5f['nodes/default/0/orientation_w'] = 0
         errors = test_module.validate(str(config_copy_path), bbp_check=True)
         assert errors == [
-            Error(Error.WARNING, 'Group default of {} has no rotation fields'.format(nodes_file)),
-            BbpError(Error.WARNING, 'Group default of {} has no rotation fields'.format(nodes_file))
+            Error(Error.WARNING, 'Group default/0 of {} has no rotation fields'.format(nodes_file)),
+            BbpError(Error.WARNING, 'Group default/0 of {} has no rotation fields'.format(nodes_file))
         ]
 
 
@@ -255,7 +255,7 @@ def test_no_morph_files():
         errors = test_module.validate(str(config_copy_path))
         assert errors == [Error(
             Error.WARNING,
-            'missing 1 files in group morphology: default[{}]:\n\tnoname.swc\n'.format(nodes_file))]
+            'missing 1 files in group morphology: default/0[{}]:\n\tnoname.swc\n'.format(nodes_file))]
 
         with h5py.File(nodes_file, 'r+') as h5f:
             morph = h5f['nodes/default/0/morphology']
@@ -263,7 +263,7 @@ def test_no_morph_files():
         errors = test_module.validate(str(config_copy_path))
         assert errors == [Error(
             Error.WARNING,
-            'missing 3 files in group morphology: default[{}]:\n\tnoname0.swc\n\t...\n'.format(
+            'missing 3 files in group morphology: default/0[{}]:\n\tnoname0.swc\n\t...\n'.format(
                 nodes_file))]
 
 
@@ -275,7 +275,7 @@ def test_no_template_files():
         errors = test_module.validate(str(config_copy_path))
         assert errors == [
             Error(Error.WARNING,
-                  'missing 1 files in group model_template: default[{}]:\n\tnoname.hoc\n'
+                  'missing 1 files in group model_template: default/0[{}]:\n\tnoname.hoc\n'
                   .format(nodes_file))]
 
 
@@ -288,9 +288,9 @@ def test_no_edges_h5():
         assert errors == [Error(Error.FATAL, 'No "edges" in {}.'.format(edges_file))]
 
 
-def test_no_required_edge_population_datasets():
+def test_no_required_edge_population_datasets_one_group():
     required_datasets = sorted([
-        'edge_type_id', 'source_node_id', 'target_node_id', 'edge_group_id', 'edge_group_index'])
+        'edge_type_id', 'source_node_id', 'target_node_id'])
     with _copy_circuit() as (circuit_copy_path, config_copy_path):
         edges_file = circuit_copy_path / 'edges.h5'
         with h5py.File(edges_file, 'r+') as h5f:
@@ -301,13 +301,102 @@ def test_no_required_edge_population_datasets():
                                 format(edges_file, required_datasets))]
 
 
+def test_no_required_edge_population_datasets_multiple_groups():
+    required_datasets = sorted([
+        'edge_type_id', 'source_node_id', 'target_node_id', 'edge_group_id', 'edge_group_index'])
+    with _copy_circuit() as (circuit_copy_path, config_copy_path):
+        edges_file = circuit_copy_path / 'edges.h5'
+        with h5py.File(edges_file, 'r+') as h5f:
+            for ds in required_datasets:
+                del h5f['edges/default/' + ds]
+            h5f.create_group('edges/default/1')
+        errors = test_module.validate(str(config_copy_path))
+        assert errors == [Error(Error.FATAL, 'Population default of {} misses datasets {}'.
+                                format(edges_file, required_datasets))]
+
+
+def test_edge_population_multiple_groups():
+    with _copy_circuit() as (circuit_copy_path, config_copy_path):
+        edges_file = circuit_copy_path / 'edges.h5'
+        with h5py.File(edges_file, 'r+') as h5f:
+            h5f.create_group('edges/default/1')
+        errors = test_module.validate(str(config_copy_path), bbp_check=True)
+        assert BbpError(Error.WARNING, 'Population default of {} have multiple groups. '
+                                       'Cannot be read via bluepysnap or libsonata'.
+                        format(edges_file)) in errors
+
+
+def test_edge_population_missing_edge_group_id_one_group():
+    with _copy_circuit() as (circuit_copy_path, config_copy_path):
+        edges_file = circuit_copy_path / 'edges.h5'
+        with h5py.File(edges_file, 'r+') as h5f:
+            del h5f['edges/default/edge_group_id']
+        errors = test_module.validate(str(config_copy_path))
+        assert errors == [Error(Error.FATAL, 'Population default of {} misses dataset {}'.
+                                format(edges_file, {"edge_group_id"}))]
+
+
+def test_edge_population_missing_edge_group_index_one_group():
+    with _copy_circuit() as (circuit_copy_path, config_copy_path):
+        edges_file = circuit_copy_path / 'edges.h5'
+        with h5py.File(edges_file, 'r+') as h5f:
+            del h5f['edges/default/edge_group_index']
+        errors = test_module.validate(str(config_copy_path))
+        assert errors == [Error(Error.FATAL, 'Population default of {} misses dataset {}'.
+                                format(edges_file, {"edge_group_index"}))]
+
+
+def test_edge_population_missing_edge_group_id_index_one_group():
+    with _copy_circuit() as (circuit_copy_path, config_copy_path):
+        edges_file = circuit_copy_path / 'edges.h5'
+        with h5py.File(edges_file, 'r+') as h5f:
+            del h5f['edges/default/edge_group_index']
+            del h5f['edges/default/edge_group_id']
+        errors = test_module.validate(str(config_copy_path))
+        assert errors == []
+
+def test_edge_population_edge_group_different_length():
+    with _copy_circuit() as (circuit_copy_path, config_copy_path):
+        edges_file = circuit_copy_path / 'edges.h5'
+        with h5py.File(edges_file, 'r+') as h5f:
+            del h5f['edges/default/edge_group_index']
+            h5f.create_dataset('edges/default/edge_group_index', data=[0, 1, 2, 3, 4])
+        errors = test_module.validate(str(config_copy_path))
+        assert errors == [Error(Error.FATAL, 'Population default of {} "edge_group_ids" and "edge_group_index" of different sizes'.
+                                format(edges_file))]
+
+
+def test_edge_population_wrong_group_id():
+    with _copy_circuit() as (circuit_copy_path, config_copy_path):
+        edges_file = circuit_copy_path / 'edges.h5'
+        with h5py.File(edges_file, 'r+') as h5f:
+            del h5f['edges/default/edge_group_id']
+            h5f.create_dataset('edges/default/edge_group_id', data=[0, 1, 0, 0])
+        errors = test_module.validate(str(config_copy_path))
+        print('Population default of {} misses group(s): {}'.
+                                format(edges_file, {1}))
+        assert errors == [Error(Error.FATAL, 'Population default of {} misses group(s): {}'.
+                                format(edges_file, {1}))]
+
+
+def test_edge_population_wrong_group_index():
+    with _copy_circuit() as (circuit_copy_path, config_copy_path):
+        edges_file = circuit_copy_path / 'edges.h5'
+        with h5py.File(edges_file, 'r+') as h5f:
+            del h5f['edges/default/edge_group_index']
+            h5f.create_dataset('edges/default/edge_group_index', data=[0, 1, 2, 12])
+        errors = test_module.validate(str(config_copy_path))
+        assert errors == [Error(Error.FATAL, 'Group default/0 in file {} should have ids up to {}'.
+                                format(edges_file, 12))]
+
+
 def test_no_required_bbp_edge_group_datasets():
     with _copy_circuit() as (circuit_copy_path, config_copy_path):
         edges_file = circuit_copy_path / 'edges.h5'
         with h5py.File(edges_file, 'r+') as h5f:
             del h5f['edges/default/0/syn_weight']
         errors = test_module.validate(str(config_copy_path), True)
-        assert errors == [BbpError(Error.WARNING, 'Group default of {} misses fields: {}'.
+        assert errors == [BbpError(Error.WARNING, 'Group default/0 of {} misses fields: {}'.
                                    format(edges_file, ['syn_weight']))]
 
 

--- a/tests/test_circuit_validation.py
+++ b/tests/test_circuit_validation.py
@@ -299,6 +299,20 @@ def test_no_edge_group():
         assert errors == []
 
 
+def test_no_edge_group_missing_requiered_datasets():
+    with _copy_circuit() as (circuit_copy_path, config_copy_path):
+        required_datasets = sorted([
+            'edge_type_id', 'source_node_id', 'target_node_id'])
+        edges_file = circuit_copy_path / 'edges.h5'
+        with h5py.File(edges_file, 'r+') as h5f:
+            del h5f['edges/default/0']
+            for ds in required_datasets:
+                del h5f['edges/default/' + ds]
+        errors = test_module.validate(str(config_copy_path))
+        assert errors == [Error(Error.FATAL, 'Population default of {} misses datasets {}'.
+                                format(edges_file, required_datasets))]
+
+
 def test_no_edge_group_no_optional_datasets():
     with _copy_circuit() as (circuit_copy_path, config_copy_path):
         optional_datasets = sorted(['edge_group_id', 'edge_group_index'])


### PR DESCRIPTION
Both fields are not mandatory and actually not supported by
libsonata and snap. These fields are not mandatory and using them would
result in a huge perf loss.

* circuits are valid if both edge_group_id/index are missing and group
  count is equal to 1.