### PR TITLE
fix for the biophysical node validation

### DIFF
--- a/tests/test_circuit_validation.py
+++ b/tests/test_circuit_validation.py
@@ -11,7 +11,8 @@ try:
 except ImportError:
     from pathlib2 import Path
 import h5py
-from six import u as unicode
+
+import six
 import bluepysnap.circuit_validation as test_module
 from bluepysnap.circuit_validation import Error, BbpError
 import numpy as np
@@ -51,7 +52,7 @@ def _edit_config(config_path):
         yield config
     finally:
         with config_path.open('w') as f:
-            f.write(unicode(json.dumps(config)))
+            f.write(six.u(json.dumps(config)))
 
 
 def test_error_comparison():
@@ -215,7 +216,9 @@ def test_ok_bio_model_type_in_library():
             data = h5f['nodes/default/0/model_type'][:]
             del h5f['nodes/default/0/model_type']
             h5f.create_dataset('nodes/default/0/model_type', data=np.zeros_like(data, dtype=int))
-            h5f.create_dataset('nodes/default/0/@library/model_type', data=np.string_(["biophysical",]))
+            dt = h5py.special_dtype(vlen=six.text_type)
+            h5f.create_dataset('nodes/default/0/@library/model_type',
+                               data=np.array(["biophysical", ], dtype=object), dtype=dt)
         errors = test_module.validate(str(config_copy_path))
         assert errors == []
 


### PR DESCRIPTION
The validation for the biophysical was missing for "in @library" use case. I added it. 