### PR TITLE
Fix circuit validation of 'node_group_id' and 'node_group_index'

### DIFF
--- a/bluepysnap/circuit_validation.py
+++ b/bluepysnap/circuit_validation.py
@@ -303,17 +303,18 @@ def _check_nodes_population(nodes_dict, config):
         if not nodes or len(nodes) == 0:
             errors.append(fatal('No "nodes" in {}.'.format(nodes_file)))
             return errors
-        if len(nodes.keys()) > 1:
-            required_datasets += ['node_group_id', 'node_group_index']
         for population_name in nodes:
             population = nodes[population_name]
+            groups = [population[name] for name in population
+                      if isinstance(population[name], h5py.Group)]
+            if len(groups) > 1:
+                required_datasets += ['node_group_id', 'node_group_index']
             missing_datasets = sorted(set(required_datasets) - set(population))
             if missing_datasets:
                 errors.append(fatal('Population {} of {} misses datasets {}'.
                                     format(population_name, nodes_file, missing_datasets)))
-            for name in population:
-                if isinstance(population[name], h5py.Group):
-                    errors += _check_nodes_group(population[name], config)
+            for group in groups:
+                errors += _check_nodes_group(group, config)
     return errors
 
 

--- a/bluepysnap/circuit_validation.py
+++ b/bluepysnap/circuit_validation.py
@@ -207,7 +207,7 @@ def _get_population_groups(population_h5):
 
 
 def _get_group_size(group_h5):
-    """Gets size of an edges or nodes group"""
+    """Gets size of an edges or nodes group."""
     for name in group_h5:
         if isinstance(group_h5[name], h5py.Dataset):
             return group_h5[name].shape[0]
@@ -215,7 +215,7 @@ def _get_group_size(group_h5):
 
 
 def _check_multi_groups(group_id_h5, group_index_h5, population):
-    """Checks multiple groups of nodes or edges population"""
+    """Checks multiple groups of nodes or edges population."""
     group_id_h5 = group_id_h5[:]
     group_index_h5 = group_index_h5[:]
     if len(group_id_h5) != len(group_index_h5):

--- a/tests/test_circuit_validation.py
+++ b/tests/test_circuit_validation.py
@@ -444,8 +444,8 @@ def test_edge_population_edge_group_different_length():
             h5f.create_dataset('edges/default/edge_group_index', data=[0, 1, 2, 3, 4])
         errors = test_module.validate(str(config_copy_path))
         assert errors == [Error(Error.FATAL,
-                                'Population default of {} "edge_group_id" and "edge_group_index" of different sizes'.
-                                format(edges_file))]
+                                'Population {} of {} has different sizes of "group_id" and "group_index"'.
+                                format('/edges/default', edges_file))]
 
 
 def test_edge_population_wrong_group_id():
@@ -455,7 +455,7 @@ def test_edge_population_wrong_group_id():
             del h5f['edges/default/edge_group_id']
             h5f.create_dataset('edges/default/edge_group_id', data=[0, 1, 0, 0])
         errors = test_module.validate(str(config_copy_path))
-        assert errors == [Error(Error.FATAL, 'Population default of {} misses group(s): {}'.
+        assert errors == [Error(Error.FATAL, 'Population /edges/default of {} misses group(s): {}'.
                                 format(edges_file, {1}))]
 
 
@@ -527,6 +527,8 @@ def test_no_edge_all_node_ids():
             del h5f['nodes/default/0']
         errors = test_module.validate(str(config_copy_path))
         assert errors == [
+            Error(Error.FATAL, 'Population /nodes/default of {} misses group(s): {}'.
+                  format(nodes_file, {0})),
             Error(Error.FATAL,
                   '/edges/default/source_node_id does not have node ids in its node population'),
             Error(Error.FATAL,

--- a/tests/test_circuit_validation.py
+++ b/tests/test_circuit_validation.py
@@ -139,13 +139,14 @@ def test_no_required_node_single_population_datasets():
                                 format(nodes_file, ['node_type_id']))]
 
 
-def test_no_required_node_multi_population_datasets():
-    required_datasets = ['node_type_id', 'node_group_id', 'node_group_index']
+def test_no_required_node_multi_group_datasets():
+    required_datasets = ['node_group_id', 'node_group_index']
     for ds in required_datasets:
         with copy_circuit() as (circuit_copy_path, config_copy_path):
             nodes_file = circuit_copy_path / 'nodes.h5'
             with h5py.File(nodes_file, 'r+') as h5f:
                 del h5f['nodes/default/' + ds]
+                h5f.copy('nodes/default/0', 'nodes/default/1')
             errors = test_module.validate(str(config_copy_path))
             assert errors == [Error(Error.FATAL, 'Population default of {} misses datasets {}'.
                                     format(nodes_file, [ds]))]

--- a/tests/test_circuit_validation.py
+++ b/tests/test_circuit_validation.py
@@ -9,9 +9,11 @@ except ImportError:
 import h5py
 
 import six
+from bluepysnap.exceptions import BluepySnapError
 import bluepysnap.circuit_validation as test_module
 from bluepysnap.circuit_validation import Error, BbpError
 import numpy as np
+import pytest
 
 from utils import TEST_DATA_DIR, copy_circuit, edit_config
 
@@ -20,6 +22,15 @@ def test_error_comparison():
     err = Error(Error.WARNING, 'hello')
     # we don't use `err == 'hello'` because of py27 compatibility
     assert (err == 'hello') is False
+
+
+def test_empty_group_size():
+    with copy_circuit() as (circuit_copy_path, config_copy_path):
+        nodes_file = circuit_copy_path / 'nodes.h5'
+        with h5py.File(nodes_file, 'r+') as h5f:
+            grp = h5f['nodes/default/'].create_group('3')
+            with pytest.raises(BluepySnapError):
+                test_module._get_group_size(grp)
 
 
 def test_ok_circuit():


### PR DESCRIPTION
'node_group_id' and 'node_group_index' must be required when multiple groups. Currently we require them when multiple populations.