### PR TITLE
Improve validation for 'edge_group_id', 'edge_group_index' and 'node_population' attribute of edges

### DIFF
--- a/bluepysnap/circuit_validation.py
+++ b/bluepysnap/circuit_validation.py
@@ -439,12 +439,13 @@ def _check_edges_node_ids(nodes_ds, nodes):
     Returns:
         list: List of errors, empty if no errors
     """
-    errors = []
+    if 'node_population' not in nodes_ds.attrs:
+        return [fatal('Missing "node_population" attribute for "{}"'.format(nodes_ds.name))]
     node_population_name = six.ensure_str(nodes_ds.attrs['node_population'])
     nodes_dict = _find_nodes_population(node_population_name, nodes)
     if not nodes_dict:
-        errors.append(fatal('No node population for "{}"'.format(nodes_ds.name)))
-        return errors
+        return [fatal('No node population for "{}"'.format(nodes_ds.name))]
+    errors = []
     with h5py.File(nodes_dict['nodes_file'], 'r') as h5f:
         node_ids = _get_node_ids(h5f['/nodes/' + node_population_name])
         if node_ids.size > 0:

--- a/bluepysnap/circuit_validation.py
+++ b/bluepysnap/circuit_validation.py
@@ -527,12 +527,9 @@ def _check_edge_population_data(population, nodes):
         return errors + [fatal('Population {} of {} misses dataset {}'.
                                format(population_name, population.file.filename,
                                       missing_group_datasets))]
-    if len(missing_group_datasets) == 2 and len(groups) == 1:
-        # no "edge_group_id", "edge_group_index" and only one group --> can use implicit ids
-        return errors
-
-    errors += _check_multi_groups(
-        population["edge_group_id"], population["edge_group_index"], population)
+    if len(missing_group_datasets) == 0:
+        errors += _check_multi_groups(
+            population["edge_group_id"], population["edge_group_index"], population)
     if 'source_node_id' in children_object_names:
         errors += _check_edges_node_ids(population['source_node_id'], nodes)
     if 'target_node_id' in children_object_names:

--- a/tests/test_circuit_validation.py
+++ b/tests/test_circuit_validation.py
@@ -579,3 +579,27 @@ def test_invalid_edge_node_ids():
             Error(Error.FATAL, 'Population {} edges [99999] have node ids [0 1] instead of '
                                'single id 0'.format(edges_file)),
         ]
+
+
+def test_explicit_edges_no_node_population_attr():
+    with copy_circuit() as (circuit_copy_path, config_copy_path):
+        edges_file = circuit_copy_path / 'edges.h5'
+        with h5py.File(edges_file, 'r+') as h5f:
+            del h5f['edges/default/source_node_id'].attrs['node_population']
+        errors = test_module.validate(str(config_copy_path))
+        assert errors == [
+            Error(Error.FATAL,
+                  'Missing "node_population" attribute for "/edges/default/source_node_id"')]
+
+
+def test_implicit_edges_no_node_population_attr():
+    with copy_circuit() as (circuit_copy_path, config_copy_path):
+        edges_file = circuit_copy_path / 'edges.h5'
+        with h5py.File(edges_file, 'r+') as h5f:
+            del h5f['edges/default/edge_group_id']
+            del h5f['edges/default/edge_group_index']
+            del h5f['edges/default/source_node_id'].attrs['node_population']
+        errors = test_module.validate(str(config_copy_path))
+        assert errors == [
+            Error(Error.FATAL,
+                  'Missing "node_population" attribute for "/edges/default/source_node_id"')]


### PR DESCRIPTION
cc @tomdele . We don't validate edges ids if there are no `edge_group_id`, `edge_group_index` provided. This should be fixed. Here I only provided tests for the start. They fail.