### PR TITLE
Fix the sample with empty group NodePopulation.ids

### DIFF
--- a/bluepysnap/nodes.py
+++ b/bluepysnap/nodes.py
@@ -428,9 +428,9 @@ class NodePopulation(object):
             result = utils.ensure_list(group)
             self._check_ids(result)
             preserve_order = isinstance(group, collections.Sequence)
-
         if sample is not None:
-            result = np.random.choice(result, sample, replace=False)
+            if len(result) > 0:
+                result = np.random.choice(result, sample, replace=False)
             preserve_order = False
         if limit is not None:
             result = result[:limit]

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -185,6 +185,8 @@ class TestNodePopulation:
         npt.assert_equal(_call(group=[]), [])
         npt.assert_equal(_call(limit=1), [0])
         npt.assert_equal(len(_call(sample=2)), 2)
+        npt.assert_equal(_call(group=[], sample=2), [])
+        npt.assert_equal(_call(group={Cell.MTYPE: "unknown"}, sample=2), [])
         npt.assert_equal(_call(0), [0])
         npt.assert_equal(_call([0, 1]), [0, 1])
         npt.assert_equal(_call([1, 0, 1]), [1, 0, 1])  # order and duplicates preserved


### PR DESCRIPTION
* Fix the sample raise if the group return empty list and sample is used