### PR TITLE
Fix deprecation warnings

### DIFF
--- a/bluepysnap/_plotting.py
+++ b/bluepysnap/_plotting.py
@@ -307,8 +307,8 @@ def spikes_firing_animation(filtered_report, x_axis=Node.X, y_axis=Node.Y,
         y_limits = [data[y_axis].min(), data[y_axis].max()]
         ax.set_xlim(*x_limits)
         ax.set_ylim(*y_limits)
-        ax.set_xlabel('{} $\mu$m'.format(x_axis))  # noqa
-        ax.set_ylabel('{} $\mu$m'.format(y_axis))  # noqa
+        ax.set_xlabel(r'{} $\mu$m'.format(x_axis))  # noqa
+        ax.set_ylabel(r'{} $\mu$m'.format(y_axis))  # noqa
 
     else:
         fig = ax.figure

--- a/bluepysnap/config.py
+++ b/bluepysnap/config.py
@@ -19,8 +19,12 @@
 
 # TODO: move to `libsonata` library
 
-import collections
 from pathlib2 import Path
+
+try:
+    from collections.abc import Mapping, Iterable
+except ImportError:
+    from collections import Mapping, Iterable
 
 import six
 
@@ -100,13 +104,13 @@ class Config(object):
             return value
 
     def _resolve(self, value):
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, Mapping):
             return {
                 k: self._resolve(v) for k, v in six.iteritems(value)
             }
         elif isinstance(value, six.string_types):
             return self._resolve_string(value)
-        elif isinstance(value, collections.Iterable):
+        elif isinstance(value, Iterable):
             return [self._resolve(v) for v in value]
         else:
             return value

--- a/bluepysnap/node_sets.py
+++ b/bluepysnap/node_sets.py
@@ -21,8 +21,12 @@ For more information see:
 https://github.com/AllenInstitute/sonata/blob/master/docs/SONATA_DEVELOPER_GUIDE.md#node-sets-file
 """
 
-import collections
 from copy import deepcopy
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 import numpy as np
 from bluepysnap.exceptions import BluepySnapError
@@ -77,9 +81,9 @@ def _resolve_set(content, resolved, node_set_name):
     set_value = deepcopy(content.get(node_set_name))
     if set_value is None:
         raise BluepySnapError("Missing node_set: '{}'".format(node_set_name))
-    if not isinstance(set_value, (collections.Mapping, list)) or not set_value:
+    if not isinstance(set_value, (Mapping, list)) or not set_value:
         raise BluepySnapError("Ambiguous node_set: '{}'".format({node_set_name: set_value}))
-    if isinstance(set_value, collections.Mapping):
+    if isinstance(set_value, Mapping):
         resolved[node_set_name] = _sanitize(set_value)
         return resolved[node_set_name]
 

--- a/bluepysnap/nodes.py
+++ b/bluepysnap/nodes.py
@@ -17,7 +17,6 @@
 
 """Node population access."""
 
-import collections
 import inspect
 from copy import deepcopy
 
@@ -27,6 +26,10 @@ import pandas as pd
 import six
 
 from cached_property import cached_property
+try:
+    from collections.abc import Mapping, Sequence
+except ImportError:
+    from collections import Mapping, Sequence
 
 from bluepysnap import utils
 from bluepysnap.exceptions import BluepySnapError
@@ -321,7 +324,7 @@ class NodePopulation(object):
                 prop_mask = np.logical_and(prop >= v1, prop <= v2)
             elif isinstance(values, six.string_types) and values.startswith('regex:'):
                 prop_mask = _complex_query(prop, {'$regex': values[6:]})
-            elif isinstance(values, collections.Mapping):
+            elif isinstance(values, Mapping):
                 prop_mask = _complex_query(prop, values)
             else:
                 prop_mask = np.in1d(prop, values)
@@ -418,7 +421,7 @@ class NodePopulation(object):
 
         if group is None:
             result = self._data.index.values
-        elif isinstance(group, collections.Mapping):
+        elif isinstance(group, Mapping):
             result = self._node_ids_by_filter(queries=group)
         elif isinstance(group, np.ndarray):
             result = group
@@ -427,7 +430,7 @@ class NodePopulation(object):
         else:
             result = utils.ensure_list(group)
             self._check_ids(result)
-            preserve_order = isinstance(group, collections.Sequence)
+            preserve_order = isinstance(group, Sequence)
         if sample is not None:
             if len(result) > 0:
                 result = np.random.choice(result, sample, replace=False)

--- a/bluepysnap/utils.py
+++ b/bluepysnap/utils.py
@@ -17,12 +17,16 @@
 
 """Miscellaneous utilities."""
 
-import collections
 import json
 import itertools
 
 import numpy as np
 import six
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 from bluepysnap.exceptions import BluepySnapError
 from bluepysnap.sonata_constants import DYNAMICS_PREFIX
@@ -36,7 +40,7 @@ def load_json(filepath):
 
 def is_iterable(v):
     """Check if `v` is any iterable (strings are considered scalar)."""
-    return isinstance(v, collections.Iterable) and not isinstance(v, six.string_types)
+    return isinstance(v, Iterable) and not isinstance(v, six.string_types)
 
 
 def ensure_list(v):


### PR DESCRIPTION
* Import ABC from collections.abc in Python 3. Fixes #89 
* Fix deprecation warning regarding invalid escape sequences.