### PR TITLE
Fix unit tests on Mac, fix doc indentation

### DIFF
--- a/bluepysnap/edges.py
+++ b/bluepysnap/edges.py
@@ -457,8 +457,8 @@ class EdgePopulation(object):
             source: source node group
             target: target node group
             unique_node_ids: if True, no node ID will be used more than once as source or
-            target for edges. Careful, this flag does not provide unique (source, target)
-            pairs but unique node IDs.
+                target for edges. Careful, this flag does not provide unique (source, target)
+                pairs but unique node IDs.
             shuffle: if True, result order would be (somewhat) randomized
             return_edge_count: if True, edge count is added to yield result
             return_edge_ids: if True, edge ID list is added to yield result

--- a/tests/test__plotting.py
+++ b/tests/test__plotting.py
@@ -11,6 +11,14 @@ def test__get_pyplot():
         with pytest.raises(ImportError):
             test_module._get_pyplot()
 
+    import matplotlib
+
+    # Set a backend different to MacOSX (default on Mac OS) to avoid the error
+    #   RuntimeError: Python is not installed as a framework
+    # using Python 2.7 in a virtualenv on Mac OS.
+    # See also https://matplotlib.org/faq/osx_framework.html.
+    matplotlib.use('pdf')
+
     import matplotlib.pyplot
     plt_test = test_module._get_pyplot()
     assert plt_test is matplotlib.pyplot

--- a/tests/test__plotting.py
+++ b/tests/test__plotting.py
@@ -2,6 +2,7 @@ import sys
 
 import mock
 import pytest
+import six
 
 import bluepysnap._plotting as test_module
 
@@ -11,13 +12,13 @@ def test__get_pyplot():
         with pytest.raises(ImportError):
             test_module._get_pyplot()
 
-    import matplotlib
-
-    # Set a backend different to MacOSX (default on Mac OS) to avoid the error
-    #   RuntimeError: Python is not installed as a framework
-    # using Python 2.7 in a virtualenv on Mac OS.
-    # See also https://matplotlib.org/faq/osx_framework.html.
-    matplotlib.use('pdf')
+    if sys.platform == 'darwin' and six.PY2:
+        # Set a backend different to MacOSX (default on Mac OS) to avoid the error
+        #   RuntimeError: Python is not installed as a framework
+        # using Python 2.7 in a virtualenv on Mac OS.
+        # See also https://matplotlib.org/faq/osx_framework.html.
+        import matplotlib
+        matplotlib.use('pdf')
 
     import matplotlib.pyplot
     plt_test = test_module._get_pyplot()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,7 +41,7 @@ def copy_circuit(config='circuit_config.json'):
     """
     with setup_tempdir() as tmp_dir:
         copy_tree(str(TEST_DATA_DIR), tmp_dir)
-        circuit_copy_path = Path(tmp_dir)
+        circuit_copy_path = Path(tmp_dir).resolve()
         yield circuit_copy_path, circuit_copy_path / config
 
 
@@ -53,7 +53,7 @@ def copy_config(config='circuit_config.json'):
         yields a path to the copy of the config file
     """
     with setup_tempdir() as tmp_dir:
-        output = Path(tmp_dir, config)
+        output = Path(tmp_dir, config).resolve()
         shutil.copy(str(TEST_DATA_DIR / config), str(output))
         yield output
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,7 +22,7 @@ TEST_DATA_DIR = TEST_DIR / 'data'
 
 @contextmanager
 def setup_tempdir(cleanup=True):
-    temp_dir = tempfile.mkdtemp()
+    temp_dir = str(Path(tempfile.mkdtemp()).resolve())
     try:
         yield temp_dir
     finally:
@@ -41,7 +41,7 @@ def copy_circuit(config='circuit_config.json'):
     """
     with setup_tempdir() as tmp_dir:
         copy_tree(str(TEST_DATA_DIR), tmp_dir)
-        circuit_copy_path = Path(tmp_dir).resolve()
+        circuit_copy_path = Path(tmp_dir)
         yield circuit_copy_path, circuit_copy_path / config
 
 
@@ -53,7 +53,7 @@ def copy_config(config='circuit_config.json'):
         yields a path to the copy of the config file
     """
     with setup_tempdir() as tmp_dir:
-        output = Path(tmp_dir, config).resolve()
+        output = Path(tmp_dir, config)
         shutil.copy(str(TEST_DATA_DIR / config), str(output))
         yield output
 


### PR DESCRIPTION
Fix unit tests on Mac
- On Mac, tempfile.mkdtemp() returns something like `/var/folders/xxx` that's a simlink to `/private/var/folders/xxx`.
This PR resolves the symbolic link to allow the comparison of errors in unit tests.
- Set `pdf` as matplotlib backend in unit tests

Minor fix in docstring indentation
