### PR TITLE
fix validation of required datasets of virtual node groups

### DIFF
--- a/bluepysnap/circuit_validation.py
+++ b/bluepysnap/circuit_validation.py
@@ -338,12 +338,14 @@ def _check_nodes_group(group_df, group, config):
     Returns:
         list: List of errors, empty if no errors
     """
-    REQUIRED_GROUP_NAMES = ['model_type', 'model_template']
-    missing_fields = sorted(set(REQUIRED_GROUP_NAMES) - set(group_df.columns.tolist()))
-    if missing_fields:
-        return [fatal('Group {} of {} misses required fields: {}'
-                      .format(_get_group_name(group, parents=1), group.file.filename,
-                              missing_fields))]
+    if 'model_type' not in group_df.columns:
+        return [fatal('Group {} of {} misses "model_type" field'
+                      .format(_get_group_name(group, parents=1), group.file.filename))]
+    if group_df['model_type'][0] == 'virtual':
+        return []
+    if 'model_template' not in group_df.columns:
+        return [fatal('Group {} of {} misses "model_template" field'
+                      .format(_get_group_name(group, parents=1), group.file.filename))]
     elif group_df['model_type'][0] == 'biophysical':
         return _check_bio_nodes_group(group_df, group, config)
     return []

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=[
         'cached_property>=1.0',
         'functools32;python_version<"3.2"',
-        'h5py>=2.2',
+        'h5py>=2.2,<3',
         'libsonata>=0.1.4',
         'neurom>=1.3',
         'numpy>=1.8',

--- a/tests/test_circuit_validation.py
+++ b/tests/test_circuit_validation.py
@@ -182,22 +182,23 @@ def test_nodes_multi_group_wrong_group_id():
 
 def test_no_required_node_group_datasets():
     required_datasets = ['model_template', 'model_type']
-    with copy_circuit() as (circuit_copy_path, config_copy_path):
-        nodes_file = circuit_copy_path / 'nodes.h5'
-        with h5py.File(nodes_file, 'r+') as h5f:
-            for ds in required_datasets:
+    for ds in required_datasets:
+        with copy_circuit() as (circuit_copy_path, config_copy_path):
+            nodes_file = circuit_copy_path / 'nodes.h5'
+            with h5py.File(nodes_file, 'r+') as h5f:
                 del h5f['nodes/default/0/' + ds]
-        errors = test_module.validate(str(config_copy_path))
-        assert errors == {Error(Error.FATAL,
-                                'Group default/0 of {} misses required fields: {}'
-                                .format(nodes_file, required_datasets))}
+            errors = test_module.validate(str(config_copy_path))
+            assert errors == {Error(Error.FATAL,
+                                    'Group default/0 of {} misses "{}" field'
+                                    .format(nodes_file, ds))}
 
 
-def test_ok_nonbio_node_group_datasets():
+def test_ok_virtual_node_group_datasets():
     with copy_circuit() as (circuit_copy_path, config_copy_path):
         nodes_file = circuit_copy_path / 'nodes.h5'
         with h5py.File(nodes_file, 'r+') as h5f:
-            h5f['nodes/default/0/model_type'][:] = ''
+            h5f['nodes/default/0/model_type'][:] = 'virtual'
+            del h5f['nodes/default/0/model_template']
         errors = test_module.validate(str(config_copy_path))
         assert errors == set()
 

--- a/tests/test_circuit_validation.py
+++ b/tests/test_circuit_validation.py
@@ -203,6 +203,15 @@ def test_ok_virtual_node_group_datasets():
         assert errors == set()
 
 
+def test_ok_nonbio_node_group_datasets():
+    with copy_circuit() as (circuit_copy_path, config_copy_path):
+        nodes_file = circuit_copy_path / 'nodes.h5'
+        with h5py.File(nodes_file, 'r+') as h5f:
+            h5f['nodes/default/0/model_type'][:] = ''
+        errors = test_module.validate(str(config_copy_path))
+        assert errors == set()
+
+
 def test_no_required_bio_node_group_datasets():
     required_datasets = sorted(['morphology', 'x', 'y', 'z'])
     with copy_circuit() as (circuit_copy_path, config_copy_path):


### PR DESCRIPTION
Some datasets are not required for virtual node groups. So we need to exclude virtual groups from most of node group checks.