### PR TITLE
Fix for inheritance with DocSubstitutionMeta

### DIFF
--- a/bluepysnap/_doctools.py
+++ b/bluepysnap/_doctools.py
@@ -25,6 +25,8 @@ def _word_swapper(doc, source_word, target_word):
     """Swap a word with another in a docstring."""
     if doc is None:
         return doc
+    if source_word is None or target_word is None:
+        return doc
     return doc.replace(source_word, target_word)
 
 
@@ -52,6 +54,7 @@ class DocSubstitutionMeta(type):
     """
     def __new__(mcs, name, parents, attrs, source_word=None, target_word=None):
         """Define the new class to return."""
+        original_attrs = attrs.copy()
         for parent in parents:
             # skip classmethod with isfunction if I use also ismethod as a predicate I can have the
             # classmethod docstring changed but then the cls argument is not automatically skipped.
@@ -62,6 +65,9 @@ class DocSubstitutionMeta(type):
                         continue
                 except AttributeError:
                     pass
+                # skip overrode functions
+                if fun_name in original_attrs:
+                    continue
                 # skip special methods
                 if fun_name.startswith("__"):
                     continue

--- a/bluepysnap/circuit.py
+++ b/bluepysnap/circuit.py
@@ -32,7 +32,7 @@ class Circuit:
         """Initializes a circuit object from a SONATA config file.
 
         Args:
-            config (str): Path to a SONATA config file.
+            config (str/dict): Path to a SONATA config file or sonata config dict.
 
         Returns:
             Circuit: A Circuit object.

--- a/tests/test__doctools.py
+++ b/tests/test__doctools.py
@@ -33,6 +33,12 @@ class TestClassB(TestClass, metaclass=test_module.DocSubstitutionMeta, source_wo
     """New class with changed docstrings."""
 
 
+class TestClassC(TestClassA):
+    def bar(self):
+        """Is overrode correctly"""
+        return 42
+
+
 def test_DocSubstitutionMeta():
     default = TestClass()
     tested = TestClassA()
@@ -49,3 +55,9 @@ def test_DocSubstitutionMeta():
     assert tested.bar.__doc__ == expected
     assert tested.foo_bar.__doc__ is None
     assert tested.__dict__ == default.__dict__
+
+    # I can inherit from a class above
+    tested = TestClassC()
+    assert tested.foo.__doc__ == TestClassA.foo.__doc__
+    assert tested.bar.__doc__ == "Is overrode correctly"
+    assert tested.bar() == 42


### PR DESCRIPTION
The inheritance for the Nodes and Edges was not working due to the overrode functions being poorly handled in the DocSubstitutionMeta metaclass.