### PR TITLE
Fix "Returning ids with get/properties" warning

### DIFF
--- a/bluepysnap/edges.py
+++ b/bluepysnap/edges.py
@@ -177,7 +177,7 @@ class Edges(NetworkObject, metaclass=AbstractDocSubstitutionMeta,
                                         CircuitEdgeIds)
 
         if properties:
-            result = self.get(result, properties)
+            return self.get(result, properties)
         return result
 
     def afferent_edges(self, node_id, properties=None):
@@ -650,7 +650,9 @@ class EdgePopulation:
         else:
             selection = self._population.connecting_edges(source_node_ids, target_edge_ids)
 
-        return self._get(selection, properties)
+        if properties:
+            return self._get(selection, properties)
+        return np.asarray(selection.flatten(), np.int64)
 
     def afferent_edges(self, node_id, properties=None):
         """Get afferent edges for given ``node_id``.

--- a/bluepysnap/exceptions.py
+++ b/bluepysnap/exceptions.py
@@ -25,5 +25,5 @@ class BluepySnapDeprecationError(Exception):
     """SNAP deprecation exception."""
 
 
-class BluepySnapDeprecationWarning(UserWarning):
+class BluepySnapDeprecationWarning(DeprecationWarning):
     """SNAP deprecation warning."""

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -62,7 +62,7 @@ def test_integration():
     circuit = test_module.Circuit(str(TEST_DATA_DIR / 'circuit_config.json'))
     node_ids = circuit.nodes.ids({"mtype": ["L6_Y", "L2_X"]})
     edge_ids = circuit.edges.afferent_edges(node_ids)
-    edge_props = circuit.edges.properties(edge_ids, properties=["syn_weight", "delay"])
+    edge_props = circuit.edges.get(edge_ids, properties=["syn_weight", "delay"])
     edge_reduced = edge_ids.limit(2)
     edge_props_reduced = edge_props.loc[edge_reduced]
     assert edge_props_reduced["syn_weight"].tolist() == [1, 1]

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -233,6 +233,9 @@ class TestEdges:
         with pytest.raises(BluepySnapError):
             self.test_obj.get(ids, properties="unknown")
 
+        with pytest.deprecated_call():
+            self.test_obj.get(ids)
+
     def test_properties(self):
         ids = CircuitEdgeIds.from_dict({"default": [0, 1, 2, 3], "default2": [0, 1, 2, 3]})
         pdt.assert_frame_equal(self.test_obj.properties(ids, properties=["other2", "@source_node"]),
@@ -727,6 +730,10 @@ class TestEdgePopulation:
         assert self.test_obj.get(
             CircuitEdgeIds.from_tuples([("default2", 0), ("default2", 1)]),
             Synapse.PRE_GID).tolist() == []
+
+    def test_get_no_properties(self):
+        with pytest.deprecated_call():
+            self.test_obj.get(0, properties=None)
 
     def test_positions_1(self):
         actual = self.test_obj.positions([0], 'afferent', 'center')


### PR DESCRIPTION
- Fix warning when using edges functions using pathway_edges as backend.
- Use DeprecationWarning as base class for BluepySnapDeprecationWarning