### PR TITLE
Ensure the dtype for the ids

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Version v0.9.1
+---------------
+
+Bug Fixes
+~~~~~~~~~
+- Ensure the dtypes as int64 for the node/edge ids (#121).
+
 
 Version v0.9.0
 ---------------

--- a/bluepysnap/circuit_ids.py
+++ b/bluepysnap/circuit_ids.py
@@ -22,7 +22,7 @@ from collections import namedtuple
 import numpy as np
 import pandas as pd
 
-import bluepysnap.utils
+from bluepysnap import utils
 from bluepysnap.exceptions import BluepySnapError
 from bluepysnap._doctools import AbstractDocSubstitutionMeta
 
@@ -76,7 +76,7 @@ class CircuitIds(abc.ABC):
                 provided.
         """
         populations = np.asarray(populations)
-        population_ids = np.asarray(population_ids)
+        population_ids = utils.ensure_ids(population_ids)
 
         if len(populations) != len(population_ids):
             raise BluepySnapError("populations and population_ids must have the same size. "
@@ -104,9 +104,9 @@ class CircuitIds(abc.ABC):
             >>> CircuitIds.from_dict({"pop1": [0,2,4], "pop2": [1,2,5]})
         """
         populations = np.empty((0,), dtype=str)
-        population_ids = np.empty((0,), dtype=np.int64)
+        population_ids = np.empty((0,), dtype=utils.IDS_DTYPE)
         for population, ids in ids_dictionary.items():
-            ids = np.asarray(ids)
+            ids = utils.ensure_ids(ids)
             population_ids = np.append(population_ids, ids)
             populations = np.append(populations, np.full(ids.shape, fill_value=population))
         index = pd.MultiIndex.from_arrays([populations, population_ids])
@@ -141,7 +141,7 @@ class CircuitIds(abc.ABC):
             numpy.array: indices corresponding to the population.
         """
         try:
-            return self.index.get_locs(bluepysnap.utils.ensure_list(population))
+            return self.index.get_locs(utils.ensure_list(population))
         except KeyError:
             return []
 

--- a/bluepysnap/edges.py
+++ b/bluepysnap/edges.py
@@ -455,7 +455,7 @@ class EdgePopulation:
 
     def _get(self, selection, properties=None):
         """Get an array of edge IDs or DataFrame with edge properties."""
-        edge_ids = np.asarray(selection.flatten(), dtype=np.int64)
+        edge_ids = utils.ensure_ids(selection.flatten())
         if properties is None:
             Deprecate.warn("Returning ids with get/properties will be removed in 1.0.0."
                            "Please use EdgePopulation.ids() instead.")

--- a/bluepysnap/edges.py
+++ b/bluepysnap/edges.py
@@ -441,9 +441,9 @@ class EdgePopulation:
 
     def _get_property(self, prop, selection):
         if prop == Edge.SOURCE_NODE_ID:
-            result = self._population.source_nodes(selection)
+            result = utils.ensure_ids(self._population.source_nodes(selection))
         elif prop == Edge.TARGET_NODE_ID:
-            result = self._population.target_nodes(selection)
+            result = utils.ensure_ids(self._population.target_nodes(selection))
         elif prop in self._attribute_names:
             result = self._population.get_attribute(prop, selection)
         elif prop in self._dynamics_params_names:
@@ -522,7 +522,7 @@ class EdgePopulation:
                 result = np.random.choice(result, min(sample, len(result)), replace=False)
         if limit is not None:
             result = result[:limit]
-        return np.asarray(result)
+        return utils.ensure_ids(result)
 
     def get(self, edge_ids, properties):
         """Edge properties as pandas DataFrame.
@@ -597,7 +597,7 @@ class EdgePopulation:
         result = self._population.source_nodes(selection)
         if unique:
             result = np.unique(result)
-        return result
+        return utils.ensure_ids(result)
 
     def efferent_nodes(self, source, unique=True):
         """Get efferent node IDs for given source ``node_id``.
@@ -622,7 +622,7 @@ class EdgePopulation:
         result = self._population.target_nodes(selection)
         if unique:
             result = np.unique(result)
-        return result
+        return utils.ensure_ids(result)
 
     def pathway_edges(self, source=None, target=None, properties=None):
         """Get edges corresponding to ``source`` -> ``target`` connections.
@@ -652,7 +652,7 @@ class EdgePopulation:
 
         if properties:
             return self._get(selection, properties)
-        return np.asarray(selection.flatten(), np.int64)
+        return utils.ensure_ids(selection.flatten())
 
     def afferent_edges(self, node_id, properties=None):
         """Get afferent edges for given ``node_id``.

--- a/bluepysnap/frame_report.py
+++ b/bluepysnap/frame_report.py
@@ -25,7 +25,7 @@ from libsonata import ElementReportReader, SonataError
 
 import bluepysnap._plotting
 from bluepysnap.exceptions import BluepySnapError
-from bluepysnap.utils import ensure_list
+from bluepysnap.utils import ensure_list, ensure_ids
 
 L = logging.getLogger(__name__)
 
@@ -121,7 +121,7 @@ class PopulationFrameReport:
         Returns:
             np.Array: Numpy array containing the node_ids included in the report
         """
-        return np.sort(np.asarray(self._frame_population.get_node_ids(), dtype=np.int64))
+        return np.sort(ensure_ids(self._frame_population.get_node_ids()))
 
 
 class FilteredFrameReport:

--- a/bluepysnap/network.py
+++ b/bluepysnap/network.py
@@ -145,7 +145,7 @@ class NetworkObject(abc.ABC):
             pops = np.full_like(pop_ids, fill_value=name_ids, dtype=str_type)
             ids.append(pop_ids)
             populations.append(pops)
-        ids = np.concatenate(ids).astype(np.int64)
+        ids = utils.ensure_ids(np.concatenate(ids))
         populations = np.concatenate(populations).astype(str_type)
         res = returned_ids_cls.from_arrays(populations, ids)
         if sample:

--- a/bluepysnap/nodes.py
+++ b/bluepysnap/nodes.py
@@ -577,7 +577,7 @@ class NodePopulation:
         if limit is not None:
             result = result[:limit]
 
-        result = np.asarray(result, dtype=np.int64)
+        result = utils.ensure_ids(result)
         if preserve_order:
             return result
         else:

--- a/bluepysnap/spike_report.py
+++ b/bluepysnap/spike_report.py
@@ -25,6 +25,7 @@ import numpy as np
 from libsonata import SpikeReader, SonataError
 
 from bluepysnap.exceptions import BluepySnapError
+from bluepysnap.utils import IDS_DTYPE
 import bluepysnap._plotting
 
 
@@ -110,7 +111,7 @@ class PopulationSpikeReport:
         res = pd.DataFrame(data=res, columns=[series_name, "times"]).set_index("times")[series_name]
         if self._sorted_by != "by_time":
             res.sort_index(inplace=True)
-        return res.astype(np.int64)
+        return res.astype(IDS_DTYPE)
 
     @cached_property
     def node_ids(self):

--- a/bluepysnap/utils.py
+++ b/bluepysnap/utils.py
@@ -29,7 +29,8 @@ from bluepysnap.circuit_ids import CircuitNodeId, CircuitEdgeId
 from bluepysnap.sonata_constants import DYNAMICS_PREFIX
 
 # dtypes for the different node and edge ids. We are using np.int64 to avoid the infamous
-# https://github.com/numpy/numpy/issues/15084 numpy problem.
+# https://github.com/numpy/numpy/issues/15084 numpy problem. This type needs to be used for
+# all returned node or edge ids.
 IDS_DTYPE = np.int64
 
 
@@ -72,6 +73,8 @@ def ensure_ids(a):
     It is quite unsafe to the use uint64 for the ids due to this problem where :
     numpy.uint64 + int --> float64
     numpy.uint64 += int --> float64
+
+    This function needs to be used everywhere node_ids or edge_ids are returned.
     """
     return np.asarray(a, IDS_DTYPE)
 

--- a/bluepysnap/utils.py
+++ b/bluepysnap/utils.py
@@ -28,6 +28,10 @@ from bluepysnap.exceptions import (BluepySnapError, BluepySnapDeprecationWarning
 from bluepysnap.circuit_ids import CircuitNodeId, CircuitEdgeId
 from bluepysnap.sonata_constants import DYNAMICS_PREFIX
 
+# dtypes for the different node and edge ids. We are using np.int64 to avoid the infamous
+# https://github.com/numpy/numpy/issues/15084 numpy problem.
+IDS_DTYPE = np.int64
+
 
 class Deprecate:
     """Class for the deprecations in BluepySnap."""
@@ -59,6 +63,17 @@ def ensure_list(v):
         return list(v)
     else:
         return [v]
+
+
+def ensure_ids(a):
+    """Convert a numpy array dtype into IDS_DTYPE.
+
+    This function is here due to the https://github.com/numpy/numpy/issues/15084 numpy issue.
+    It is quite unsafe to the use uint64 for the ids due to this problem where :
+    numpy.uint64 + int --> float64
+    numpy.uint64 += int --> float64
+    """
+    return np.asarray(a, IDS_DTYPE)
 
 
 def add_dynamic_prefix(properties):

--- a/tests/test_circuit_ids.py
+++ b/tests/test_circuit_ids.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from bluepysnap.exceptions import BluepySnapError
 import bluepysnap.circuit_ids as test_module
+from bluepysnap.utils import IDS_DTYPE
 
 from utils import setup_tempdir
 
@@ -174,8 +175,10 @@ class TestCircuitNodeIds:
     def test_get_ids(self):
         tested = self.test_obj_sorted.get_ids()
         npt.assert_equal(tested, [0, 1, 2, 0])
+        npt.assert_equal(tested.dtype, IDS_DTYPE)
         tested = self.test_obj_unsorted.get_ids()
         npt.assert_equal(tested, [0, 1, 0, 2])
+        npt.assert_equal(tested.dtype, IDS_DTYPE)
 
         tested = self.test_obj_sorted.get_ids(unique=True)
         npt.assert_equal(tested, [0, 1, 2])

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -15,15 +15,16 @@ from bluepysnap.sonata_constants import Edge
 from bluepysnap.node_sets import NodeSets
 from bluepysnap.circuit import Circuit
 from bluepysnap.circuit_ids import CircuitEdgeId, CircuitEdgeIds, CircuitNodeIds, CircuitNodeId
+from bluepysnap.utils import IDS_DTYPE
 
 import bluepysnap.edges as test_module
 
 from utils import TEST_DATA_DIR, create_node_population
 
 
-def index_as_int64(values):
-    '''have pandas index types match'''
-    return np.array(values, dtype=np.int64)
+def index_as_ids_dtypes(values):
+    """have pandas index types match"""
+    return np.array(values, dtype=IDS_DTYPE)
 
 
 def test_estimate_range_size_1():
@@ -108,7 +109,7 @@ class TestEdges:
                 'int64'), dtype('int64'), dtype('float64'), dtype('float64'), dtype(
                 'float64'), dtype('float64'), dtype('float64'), dtype('float64'), dtype(
                 'float32'), dtype('float32'), dtype('float64'), dtype('float64'),
-                  dtype('uint64'), dtype('uint64'), dtype('O'), dtype('int32')]
+                  IDS_DTYPE, IDS_DTYPE, dtype('O'), dtype('int32')]
             , index=['syn_weight', '@dynamics:param1', 'afferent_surface_y',
                      'afferent_surface_z', 'conductance', 'efferent_center_x',
                      'delay', 'afferent_center_z', 'efferent_section_id',
@@ -139,7 +140,9 @@ class TestEdges:
         np.random.seed(42)
         # single edge ID --> CircuitEdgeIds return populations with the 0 id
         expected = CircuitEdgeIds.from_tuples([("default", 0), ("default2", 0)])
-        assert self.test_obj.ids(0) == expected
+        returned = self.test_obj.ids(0)
+        assert returned == expected
+        npt.assert_equal(returned.get_ids().dtype, IDS_DTYPE)
 
         # single edge ID list --> CircuitEdgeIds return populations with the 0 id
         expected = CircuitEdgeIds.from_tuples([("default", 0), ("default2", 0)])
@@ -627,7 +630,7 @@ class TestEdgePopulation:
                 'int64'), dtype('int64'), dtype('float64'), dtype('float64'), dtype(
                 'float64'), dtype('float64'), dtype('float64'), dtype('float64'), dtype(
                 'float32'), dtype('float32'), dtype('float64'), dtype('float64'),
-                  dtype('uint64'), dtype('uint64')]
+                  dtype('int64'), dtype('int64')]
             , index=['syn_weight', '@dynamics:param1', 'afferent_surface_y',
                      'afferent_surface_z', 'conductance', 'efferent_center_x',
                      'delay', 'afferent_center_z', 'efferent_section_id',
@@ -642,7 +645,10 @@ class TestEdgePopulation:
         pdt.assert_series_equal(expected, self.test_obj.property_dtypes)
 
     def test_ids(self):
-        npt.assert_equal(self.test_obj.ids(), np.array([0, 1, 2, 3]))
+        returned = self.test_obj.ids()
+        npt.assert_equal(returned, np.array([0, 1, 2, 3]))
+        npt.assert_equal(returned.dtype, IDS_DTYPE)
+
         assert self.test_obj.ids(0) == [0]
         npt.assert_equal(self.test_obj.ids([0, 1]), np.array([0, 1]))
         npt.assert_equal(self.test_obj.ids(np.array([0, 1])), np.array([0, 1]))
@@ -678,7 +684,7 @@ class TestEdgePopulation:
                 (0, 1, 88.1862, 1111., 1.),
             ],
             columns=properties,
-            index=index_as_int64(edge_ids)
+            index=index_as_ids_dtypes(edge_ids)
         )
         pdt.assert_frame_equal(actual, expected, check_dtype=False)
 
@@ -686,7 +692,7 @@ class TestEdgePopulation:
         prop = Synapse.AXONAL_DELAY
         edge_ids = [1, 0]
         actual = self.test_obj.get(edge_ids, prop)
-        expected = pd.Series([88.1862, 99.8945], index=index_as_int64(edge_ids), name=prop)
+        expected = pd.Series([88.1862, 99.8945], index=index_as_ids_dtypes(edge_ids), name=prop)
         pdt.assert_series_equal(actual, expected, check_dtype=False)
 
     def test_get_3(self):
@@ -740,7 +746,7 @@ class TestEdgePopulation:
         expected = pd.DataFrame([
             [1110., 1120., 1130.]
         ],
-            index=index_as_int64([0]),
+            index=index_as_ids_dtypes([0]),
             columns=['x', 'y', 'z']
         )
         pdt.assert_frame_equal(actual, expected)
@@ -750,7 +756,7 @@ class TestEdgePopulation:
         expected = pd.DataFrame([
             [1211., 1221., 1231.]
         ],
-            index=index_as_int64([1]),
+            index=index_as_ids_dtypes([1]),
             columns=['x', 'y', 'z']
         )
         pdt.assert_frame_equal(actual, expected)
@@ -760,7 +766,7 @@ class TestEdgePopulation:
         expected = pd.DataFrame([
             [2112., 2122., 2132.]
         ],
-            index=index_as_int64([2]),
+            index=index_as_ids_dtypes([2]),
             columns=['x', 'y', 'z']
         )
         pdt.assert_frame_equal(actual, expected)
@@ -770,7 +776,7 @@ class TestEdgePopulation:
         expected = pd.DataFrame([
             [2213., 2223., 2233.]
         ],
-            index=index_as_int64([3]),
+            index=index_as_ids_dtypes([3]),
             columns=['x', 'y', 'z']
         )
         pdt.assert_frame_equal(actual, expected)
@@ -784,7 +790,10 @@ class TestEdgePopulation:
             self.test_obj.positions([2], 'afferent', 'err')
 
     def test_afferent_nodes(self):
-        npt.assert_equal(self.test_obj.afferent_nodes(0), [2])
+        returned = self.test_obj.afferent_nodes(0)
+        npt.assert_equal(returned, [2])
+        npt.assert_equal(returned.dtype, IDS_DTYPE)
+
         npt.assert_equal(self.test_obj.afferent_nodes(0, unique=False), [2])
 
         npt.assert_equal(self.test_obj.afferent_nodes(1), [0, 2])
@@ -805,7 +814,10 @@ class TestEdgePopulation:
         npt.assert_equal(self.test_obj.afferent_nodes(None, unique=False), [2, 0, 0, 2])
 
     def test_efferent_nodes(self):
-        npt.assert_equal(self.test_obj.efferent_nodes(0), [1])
+        returned = self.test_obj.efferent_nodes(0)
+        npt.assert_equal(returned, [1])
+        npt.assert_equal(returned.dtype, IDS_DTYPE)
+
         npt.assert_equal(self.test_obj.efferent_nodes(0, unique=False), [1, 1])
 
         npt.assert_equal(self.test_obj.efferent_nodes(1), [])
@@ -827,10 +839,9 @@ class TestEdgePopulation:
         npt.assert_equal(self.test_obj.efferent_nodes(None, unique=False), [0, 1, 1, 1])
 
     def test_afferent_edges(self):
-        npt.assert_equal(
-            self.test_obj.afferent_edges([0, 1], None),
-            [0, 1, 2, 3]
-        )
+        returned = self.test_obj.afferent_edges([0, 1], None)
+        npt.assert_equal(returned, [0, 1, 2, 3])
+        npt.assert_equal(returned.dtype, IDS_DTYPE)
 
     def test_afferent_edges_1(self):
         npt.assert_equal(
@@ -848,16 +859,15 @@ class TestEdgePopulation:
                     [52.1881],
                     [11.1058],
                 ],
-                columns=properties, index=index_as_int64([1, 2, 3])
+                columns=properties, index=index_as_ids_dtypes([1, 2, 3])
             ),
             check_dtype=False
         )
 
     def test_efferent_edges_1(self):
-        npt.assert_equal(
-            self.test_obj.efferent_edges(2, None),
-            [0, 3]
-        )
+        returned = self.test_obj.efferent_edges(2, None)
+        npt.assert_equal(returned, [0, 3])
+        npt.assert_equal(returned.dtype, IDS_DTYPE)
 
     def test_efferent_edges_2(self):
         properties = [Synapse.AXONAL_DELAY]
@@ -868,20 +878,24 @@ class TestEdgePopulation:
                     [99.8945],
                     [11.1058],
                 ],
-                columns=properties, index=index_as_int64([0, 3])
+                columns=properties, index=index_as_ids_dtypes([0, 3])
             ),
             check_dtype=False
         )
 
     def test_pair_edges_1(self):
-        npt.assert_equal(self.test_obj.pair_edges(0, 2, None), [])
+        returned = self.test_obj.pair_edges(0, 2, None)
+        npt.assert_equal(returned, [])
+        npt.assert_equal(returned.dtype, IDS_DTYPE)
 
     def test_pair_edges_2(self):
         actual = self.test_obj.pair_edges(0, 2, [Synapse.AXONAL_DELAY])
         assert actual.empty
 
     def test_pair_edges_3(self):
-        npt.assert_equal(self.test_obj.pair_edges(2, 0, None), [0])
+        returned = self.test_obj.pair_edges(2, 0, None)
+        npt.assert_equal(returned, [0])
+        npt.assert_equal(returned.dtype, IDS_DTYPE)
 
     def test_pair_edges_4(self):
         properties = [Synapse.AXONAL_DELAY]
@@ -891,7 +905,7 @@ class TestEdgePopulation:
                 [
                     [99.8945],
                 ],
-                columns=properties, index=index_as_int64([0])
+                columns=properties, index=index_as_ids_dtypes([0])
             ),
             check_dtype=False
         )
@@ -905,16 +919,15 @@ class TestEdgePopulation:
                     [88.1862],
                     [52.1881],
                 ],
-                columns=properties, index=index_as_int64([1, 2])
+                columns=properties, index=index_as_ids_dtypes([1, 2])
             ),
             check_dtype=False
         )
 
     def test_pathway_edges_2(self):
-        npt.assert_equal(
-            self.test_obj.pathway_edges([1, 2], [0, 2], None),
-            [0]
-        )
+        returned = self.test_obj.pathway_edges([1, 2], [0, 2], None)
+        npt.assert_equal(returned, [0])
+        npt.assert_equal(returned.dtype, IDS_DTYPE)
 
     def test_pathway_edges_3(self):
         npt.assert_equal(

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -140,9 +140,9 @@ class TestEdges:
         np.random.seed(42)
         # single edge ID --> CircuitEdgeIds return populations with the 0 id
         expected = CircuitEdgeIds.from_tuples([("default", 0), ("default2", 0)])
-        returned = self.test_obj.ids(0)
-        assert returned == expected
-        npt.assert_equal(returned.get_ids().dtype, IDS_DTYPE)
+        tested = self.test_obj.ids(0)
+        assert tested == expected
+        npt.assert_equal(tested.get_ids().dtype, IDS_DTYPE)
 
         # single edge ID list --> CircuitEdgeIds return populations with the 0 id
         expected = CircuitEdgeIds.from_tuples([("default", 0), ("default2", 0)])
@@ -645,9 +645,9 @@ class TestEdgePopulation:
         pdt.assert_series_equal(expected, self.test_obj.property_dtypes)
 
     def test_ids(self):
-        returned = self.test_obj.ids()
-        npt.assert_equal(returned, np.array([0, 1, 2, 3]))
-        npt.assert_equal(returned.dtype, IDS_DTYPE)
+        tested = self.test_obj.ids()
+        npt.assert_equal(tested, np.array([0, 1, 2, 3]))
+        npt.assert_equal(tested.dtype, IDS_DTYPE)
 
         assert self.test_obj.ids(0) == [0]
         npt.assert_equal(self.test_obj.ids([0, 1]), np.array([0, 1]))
@@ -790,9 +790,9 @@ class TestEdgePopulation:
             self.test_obj.positions([2], 'afferent', 'err')
 
     def test_afferent_nodes(self):
-        returned = self.test_obj.afferent_nodes(0)
-        npt.assert_equal(returned, [2])
-        npt.assert_equal(returned.dtype, IDS_DTYPE)
+        tested = self.test_obj.afferent_nodes(0)
+        npt.assert_equal(tested, [2])
+        npt.assert_equal(tested.dtype, IDS_DTYPE)
 
         npt.assert_equal(self.test_obj.afferent_nodes(0, unique=False), [2])
 
@@ -814,9 +814,9 @@ class TestEdgePopulation:
         npt.assert_equal(self.test_obj.afferent_nodes(None, unique=False), [2, 0, 0, 2])
 
     def test_efferent_nodes(self):
-        returned = self.test_obj.efferent_nodes(0)
-        npt.assert_equal(returned, [1])
-        npt.assert_equal(returned.dtype, IDS_DTYPE)
+        tested = self.test_obj.efferent_nodes(0)
+        npt.assert_equal(tested, [1])
+        npt.assert_equal(tested.dtype, IDS_DTYPE)
 
         npt.assert_equal(self.test_obj.efferent_nodes(0, unique=False), [1, 1])
 
@@ -839,9 +839,9 @@ class TestEdgePopulation:
         npt.assert_equal(self.test_obj.efferent_nodes(None, unique=False), [0, 1, 1, 1])
 
     def test_afferent_edges(self):
-        returned = self.test_obj.afferent_edges([0, 1], None)
-        npt.assert_equal(returned, [0, 1, 2, 3])
-        npt.assert_equal(returned.dtype, IDS_DTYPE)
+        tested = self.test_obj.afferent_edges([0, 1], None)
+        npt.assert_equal(tested, [0, 1, 2, 3])
+        npt.assert_equal(tested.dtype, IDS_DTYPE)
 
     def test_afferent_edges_1(self):
         npt.assert_equal(
@@ -865,9 +865,9 @@ class TestEdgePopulation:
         )
 
     def test_efferent_edges_1(self):
-        returned = self.test_obj.efferent_edges(2, None)
-        npt.assert_equal(returned, [0, 3])
-        npt.assert_equal(returned.dtype, IDS_DTYPE)
+        tested = self.test_obj.efferent_edges(2, None)
+        npt.assert_equal(tested, [0, 3])
+        npt.assert_equal(tested.dtype, IDS_DTYPE)
 
     def test_efferent_edges_2(self):
         properties = [Synapse.AXONAL_DELAY]
@@ -884,18 +884,18 @@ class TestEdgePopulation:
         )
 
     def test_pair_edges_1(self):
-        returned = self.test_obj.pair_edges(0, 2, None)
-        npt.assert_equal(returned, [])
-        npt.assert_equal(returned.dtype, IDS_DTYPE)
+        tested = self.test_obj.pair_edges(0, 2, None)
+        npt.assert_equal(tested, [])
+        npt.assert_equal(tested.dtype, IDS_DTYPE)
 
     def test_pair_edges_2(self):
         actual = self.test_obj.pair_edges(0, 2, [Synapse.AXONAL_DELAY])
         assert actual.empty
 
     def test_pair_edges_3(self):
-        returned = self.test_obj.pair_edges(2, 0, None)
-        npt.assert_equal(returned, [0])
-        npt.assert_equal(returned.dtype, IDS_DTYPE)
+        tested = self.test_obj.pair_edges(2, 0, None)
+        npt.assert_equal(tested, [0])
+        npt.assert_equal(tested.dtype, IDS_DTYPE)
 
     def test_pair_edges_4(self):
         properties = [Synapse.AXONAL_DELAY]
@@ -925,9 +925,9 @@ class TestEdgePopulation:
         )
 
     def test_pathway_edges_2(self):
-        returned = self.test_obj.pathway_edges([1, 2], [0, 2], None)
-        npt.assert_equal(returned, [0])
-        npt.assert_equal(returned.dtype, IDS_DTYPE)
+        tested = self.test_obj.pathway_edges([1, 2], [0, 2], None)
+        npt.assert_equal(tested, [0])
+        npt.assert_equal(tested.dtype, IDS_DTYPE)
 
     def test_pathway_edges_3(self):
         npt.assert_equal(

--- a/tests/test_frame_report.py
+++ b/tests/test_frame_report.py
@@ -10,6 +10,7 @@ import bluepysnap.frame_report as test_module
 from bluepysnap.exceptions import BluepySnapError
 from bluepysnap.bbp import Cell
 from bluepysnap.circuit_ids import CircuitNodeIds, CircuitNodeId
+from bluepysnap.utils import IDS_DTYPE
 
 from utils import TEST_DATA_DIR
 
@@ -194,7 +195,6 @@ class TestPopulationCompartmentReport:
 
     def test_get(self):
         pdt.assert_frame_equal(self.test_obj.get(), self.df)
-
         pdt.assert_frame_equal(self.test_obj.get([]), pd.DataFrame())
         pdt.assert_frame_equal(self.test_obj.get(np.array([])), pd.DataFrame())
         pdt.assert_frame_equal(self.test_obj.get(()), pd.DataFrame())
@@ -260,7 +260,7 @@ class TestPopulationCompartmentReport:
             pdt.assert_frame_equal(self.test_obj.get([4]), pd.DataFrame())
 
     def test_node_ids(self):
-        npt.assert_array_equal(self.test_obj.node_ids, np.array(sorted([0, 1, 2]), dtype=np.int64))
+        npt.assert_array_equal(self.test_obj.node_ids, np.array(sorted([0, 1, 2]), dtype=IDS_DTYPE))
 
 
 class TestPopulationSomaReport(TestPopulationCompartmentReport):

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -18,6 +18,7 @@ from bluepysnap.circuit import Circuit
 from bluepysnap.node_sets import NodeSets
 from bluepysnap.circuit_ids import CircuitNodeIds, CircuitNodeId
 from bluepysnap.exceptions import BluepySnapError
+from bluepysnap.utils import IDS_DTYPE
 
 import bluepysnap.nodes as test_module
 
@@ -106,6 +107,7 @@ class TestNodes:
         tested = self.test_obj.ids()
         expected = CircuitNodeIds.from_dict({"default": [0, 1, 2], "default2": [0, 1, 2, 3]})
         assert tested == expected
+        npt.assert_equal(tested.get_ids().dtype, IDS_DTYPE)
 
         # CircuitNodeIds --> CircuitNodeIds and check if the population and node ids exist
         ids = CircuitNodeIds.from_arrays(["default", "default2"], [0, 3])
@@ -452,6 +454,7 @@ class TestNodePopulation:
     def test_ids(self):
         _call = self.test_obj.ids
         npt.assert_equal(_call(), [0, 1, 2])
+        npt.assert_equal(_call().dtype, IDS_DTYPE)
         npt.assert_equal(_call(group={}), [0, 1, 2])
         npt.assert_equal(_call(group=[]), [])
         npt.assert_equal(_call(limit=1), [0])

--- a/tests/test_spike_report.py
+++ b/tests/test_spike_report.py
@@ -11,6 +11,7 @@ import bluepysnap.spike_report as test_module
 from bluepysnap.exceptions import BluepySnapError
 from bluepysnap.bbp import Cell
 from bluepysnap.circuit_ids import CircuitNodeIds, CircuitNodeId
+from bluepysnap.utils import IDS_DTYPE
 
 from utils import TEST_DATA_DIR
 
@@ -128,6 +129,7 @@ class TestPopulationSpikeReport:
     def test_nodes(self):
         node_ids = self.test_obj.get([2], t_start=0.5).to_numpy()[0]
         assert self.test_obj.nodes.get(group=node_ids, properties=Cell.MTYPE) == "L6_Y"
+        npt.assert_equal(node_ids.dtype, IDS_DTYPE)
 
     def test_nodes_invalid_population(self):
         test_obj = test_module.SpikeReport(self.simulation)["default2"]
@@ -141,8 +143,11 @@ class TestPopulationSpikeReport:
         npt.assert_array_equal(self.test_obj._resolve_nodes("Node12_L6_Y"), [1, 2])
 
     def test_get(self):
-        pdt.assert_series_equal(self.test_obj.get(),
+        tested = self.test_obj.get()
+        pdt.assert_series_equal(tested,
                                 _create_series([2, 0, 1, 2, 0], [0.1, 0.2, 0.3, 0.7, 1.3]))
+        npt.assert_equal(tested.dtype, IDS_DTYPE)
+
         pdt.assert_series_equal(self.test_obj.get([]), _create_series([], []))
         pdt.assert_series_equal(self.test_obj.get(np.array([])), _create_series([], []))
         pdt.assert_series_equal(self.test_obj.get(()), _create_series([], []))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,12 @@ def test_ensure_list():
     assert test_module.ensure_list('abc') == ['abc']
 
 
+def test_ensure_ids():
+    res = test_module.ensure_ids(np.array([1, 2, 3], dtype=np.uint64))
+    npt.assert_equal(res, np.array([1, 2, 3], dtype=test_module.IDS_DTYPE))
+    npt.assert_equal(res.dtype, test_module.IDS_DTYPE)
+
+
 def test_add_dynamic_prefix():
     assert test_module.add_dynamic_prefix(["a", "b"]) == [DYNAMICS_PREFIX + "a",
                                                           DYNAMICS_PREFIX + "b"]


### PR DESCRIPTION
It is quite unsafe to the use uint64 for the ids due to the numpy issue:
https://github.com/numpy/numpy/issues/15084

Where :
numpy.uint64 + int --> float64
numpy.uint64 += int --> float64

So it fixes the ids dtype to int64 until the issue in numpy is fixed.

- add a IDS_DTYPE to contain the ids dtype
- add a ensure_ids function
- add ensure_ids when ids are returned