### PR TITLE
Improve perf for positional mask

### DIFF
--- a/bluepysnap/query.py
+++ b/bluepysnap/query.py
@@ -42,9 +42,11 @@ def _positional_mask(data, ids):
     """
     if ids is None:
         return np.full(len(data), fill_value=True)
+    if isinstance(ids, int):
+        ids = [ids]
     mask = np.full(len(data), fill_value=False)
-    valid_ids = pd.Index(utils.ensure_list(ids)).intersection(data.index)
-    mask[valid_ids] = True
+    indices = data.index.get_indexer(ids)
+    mask[indices[indices > -1]] = True
     return mask
 
 

--- a/bluepysnap/query.py
+++ b/bluepysnap/query.py
@@ -3,7 +3,6 @@ from collections.abc import Mapping
 from copy import deepcopy
 
 import numpy as np
-import pandas as pd
 from bluepysnap.exceptions import BluepySnapError
 from bluepysnap import utils
 


### PR DESCRIPTION
- improve perfs for the positional mask
- positional mask still correct if ids are not monotonic starting from 0

Tests : 
```
df = pd.DataFrame(index=np.arange(5000000))

test_ids = np.random.randint(len(df), size=50)
%timeit _positional_mask_old(df, test_ids)
115 ms ± 910 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
%timeit _positional_mask(df, test_ids)
95.2 µs ± 417 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

test_ids = np.random.randint(len(df), size=50000)
%timeit _positional_mask_old(df, test_ids)
141 ms ± 3.89 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
%timeit _positional_mask(df, test_ids)
2.32 ms ± 87.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

test_ids = np.random.randint(len(df), size=3000000)
%timeit _positional_mask_old(df, test_ids)
1.05 s ± 15 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit _positional_mask(df, test_ids)
111 ms ± 2.33 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

df = pd.DataFrame(index=np.arange(50000000))
test_ids = np.random.randint(len(df), size=3000000)
%timeit _positional_mask_old(df, test_ids)
2.45 s ± 24 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit _positional_mask(df, test_ids)
112 ms ± 2.25 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
