### PR TITLE
Adding the h5 and csv files as properties from Storage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version v0.12.1
+---------------
+
+New Features
+~~~~~~~~~~~~~
+- Adding the h5 and csv file accessors to the Node/EdgeStorage classes.
+
+
 Version v0.12.0
 ---------------
 

--- a/bluepysnap/edges.py
+++ b/bluepysnap/edges.py
@@ -318,6 +318,16 @@ class EdgeStorage:
         return self.storage.population_names
 
     @property
+    def h5_filepath(self):
+        """Returns the filepath of the Storage."""
+        return self._h5_filepath
+
+    @property
+    def csv_filepath(self):
+        """Returns the csv filepath of the Storage."""
+        return self._csv_filepath
+
+    @property
     def circuit(self):
         """Returns the circuit object containing this storage."""
         return self._circuit

--- a/bluepysnap/nodes.py
+++ b/bluepysnap/nodes.py
@@ -171,6 +171,16 @@ class NodeStorage:
         return self.storage.population_names
 
     @property
+    def h5_filepath(self):
+        """Returns the filepath of the Storage."""
+        return self._h5_filepath
+
+    @property
+    def csv_filepath(self):
+        """Returns the csv filepath of the Storage."""
+        return self._csv_filepath
+
+    @property
     def circuit(self):
         """Returns the circuit object containing this storage."""
         return self._circuit

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -583,6 +583,12 @@ class TestEdgeStorage:
     def test_storage(self):
         assert isinstance(self.test_obj.storage, libsonata.EdgeStorage)
 
+    def test_h5_filepath(self):
+        assert self.test_obj.h5_filepath == str(TEST_DATA_DIR / 'edges.h5')
+
+    def test_csv_filepath(self):
+        assert self.test_obj.csv_filepath is None
+
     def test_population_names(self):
         assert sorted(list(self.test_obj.population_names)) == ["default", "default2"]
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -311,6 +311,12 @@ class TestNodeStorage:
     def test_population_names(self):
         assert sorted(list(self.test_obj.population_names)) == ["default", "default2"]
 
+    def test_h5_filepath(self):
+        assert self.test_obj.h5_filepath == str(TEST_DATA_DIR / 'nodes.h5')
+
+    def test_csv_filepath(self):
+        assert self.test_obj.csv_filepath is None
+
     def test_circuit(self):
         assert self.test_obj.circuit is self.circuit
 


### PR DESCRIPTION
* Adding the h5 and csv file accessors to the Node/EdgeStorage classes.

This can be useful for some heritage usecases where you need to access the original file and not just the population. 