### PR TITLE
Add python 3.9 tests

### DIFF
--- a/.github/workflows/publish-sdist.yml
+++ b/.github/workflows/publish-sdist.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Build a source tarball
         run:
             python setup.py sdist

--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,10 +28,10 @@ jobs:
       run: |
         tox
     - name: Upload to codecov
-      if: ${{matrix.python-version == '3.8'}}
+      if: ${{matrix.python-version == '3.9'}}
       uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: false
         files: ./coverage.xml
         flags: pytest
-        name: "bluepysnap-py38"
+        name: "bluepysnap-py39"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,13 @@ Changelog
 Version v0.13.1
 ---------------
 
+Improvements
+~~~~~~~~~~~~
+- Add python 3.9 tests
+
 Removed
 ~~~~~~~
 - Drop python 3.6 support
-- Add python 3.9 tests
 
 
 Version v0.13.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ Version v0.13.1
 
 Removed
 ~~~~~~~
-- Drop python3.6 support
+- Drop python 3.6 support
+- Add python 3.9 tests
 
 
 Version v0.13.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,11 +6,15 @@ Version v0.13.1
 
 Improvements
 ~~~~~~~~~~~~
-- Add python 3.9 tests
+- Add python 3.9 tests.
+
+Bug Fixes
+~~~~~~~~~
+- Ensure that ids in frame reports are always np.int64 even when using libsonata 0.1.10.
 
 Removed
 ~~~~~~~
-- Drop python 3.6 support
+- Drop python 3.6 support.
 
 
 Version v0.13.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Improvements
 Bug Fixes
 ~~~~~~~~~
 - Ensure that ids in frame reports are always np.int64 even when using libsonata 0.1.10.
+- Fix deprecation warnings.
 
 Removed
 ~~~~~~~

--- a/bluepysnap/_plotting.py
+++ b/bluepysnap/_plotting.py
@@ -22,7 +22,7 @@ from more_itertools import roundrobin
 
 from bluepysnap.exceptions import BluepySnapError
 from bluepysnap.sonata_constants import Node
-
+from bluepysnap.utils import IDS_DTYPE
 
 L = logging.getLogger(__name__)
 
@@ -133,8 +133,9 @@ def spike_raster(filtered_report, y_axis=None, ax=None):  # pragma: no cover
 
     report = filtered_report.report
 
-    dtype = spike_report[population_names[0]].nodes.property_dtypes[y_axis] if y_axis else None
-    if dtype and pd.api.types.is_categorical_dtype(dtype):
+    # use np.int64 if displaying node_ids
+    dtype = spike_report[population_names[0]].nodes.property_dtypes[y_axis] if y_axis else IDS_DTYPE
+    if pd.api.types.is_categorical_dtype(dtype):
         # this is to prevent the problems when concatenating categoricals with unknown categories
         dtype = str
     data = pd.Series(index=report.index, dtype=dtype)

--- a/bluepysnap/edges.py
+++ b/bluepysnap/edges.py
@@ -102,15 +102,19 @@ class Edges(NetworkObject, metaclass=AbstractDocSubstitutionMeta,
         if edge_ids is None:
             raise BluepySnapError("You need to set edge_ids in get.")
         if properties is None:
-            Deprecate.warn("Returning ids with get/properties will be removed in 1.0.0."
-                           "Please use Edges.ids() instead.")
+            Deprecate.warn(
+                "Returning ids with get/properties is deprecated and will be removed in 1.0.0. "
+                "Please use Edges.ids instead."
+            )
             return edge_ids
         return super().get(edge_ids, properties)
 
     def properties(self, edge_ids, properties):
         """Doc is overridden below."""
-        Deprecate.warn("Edges.properties function will be deprecated in 1.0.0. Please use "
-                       "Edges.get instead.")
+        Deprecate.warn(
+            "Edges.properties function is deprecated and will be removed in 1.0.0. "
+            "Please use Edges.get instead."
+        )
         return self.get(edge_ids, properties)
 
     properties.__doc__ = get.__doc__
@@ -489,8 +493,10 @@ class EdgePopulation:
         """Get an array of edge IDs or DataFrame with edge properties."""
         edge_ids = utils.ensure_ids(selection.flatten())
         if properties is None:
-            Deprecate.warn("Returning ids with get/properties will be removed in 1.0.0."
-                           "Please use EdgePopulation.ids() instead.")
+            Deprecate.warn(
+                "Returning ids with get/properties is deprecated and will be removed in 1.0.0. "
+                "Please use EdgePopulation.ids instead."
+            )
             return edge_ids
 
         if utils.is_iterable(properties):
@@ -614,8 +620,10 @@ class EdgePopulation:
 
     def properties(self, edge_ids, properties):
         """Doc is overridden below."""
-        Deprecate.warn("EdgePopulation.properties function will be deprecated in 1.0.0. Please use "
-                       "EdgePopulation.get instead.")
+        Deprecate.warn(
+            "EdgePopulation.properties function is deprecated and will be removed in 1.0.0. "
+            "Please use EdgePopulation.get instead."
+        )
         return self.get(edge_ids, properties)
 
     properties.__doc__ = get.__doc__

--- a/bluepysnap/frame_report.py
+++ b/bluepysnap/frame_report.py
@@ -106,9 +106,11 @@ class PopulationFrameReport:
         if len(view.ids) == 0:
             return pd.DataFrame()
 
-        res = pd.DataFrame(data=view.data,
-                           columns=pd.MultiIndex.from_arrays(np.asarray(view.ids, dtype="int64").T),
-                           index=view.times).sort_index(axis=1)
+        res = pd.DataFrame(
+            data=view.data,
+            columns=pd.MultiIndex.from_arrays(np.asarray(view.ids, dtype=np.int64).T),
+            index=view.times,
+        ).sort_index(axis=1)
 
         # rename from multi index to index cannot be achieved easily through df.rename
         res.columns = self._wrap_columns(res.columns)

--- a/bluepysnap/frame_report.py
+++ b/bluepysnap/frame_report.py
@@ -106,9 +106,12 @@ class PopulationFrameReport:
         if len(view.ids) == 0:
             return pd.DataFrame()
 
+        # cell ids and section ids in the columns are enforced to be int64
+        # to avoid issues with numpy automatic conversions and to ensure that
+        # the results are the same regardless of the libsonata version [NSETM-1766]
         res = pd.DataFrame(
             data=view.data,
-            columns=pd.MultiIndex.from_arrays(np.asarray(view.ids, dtype=np.int64).T),
+            columns=pd.MultiIndex.from_arrays(ensure_ids(view.ids).T),
             index=view.times,
         ).sort_index(axis=1)
 

--- a/bluepysnap/frame_report.py
+++ b/bluepysnap/frame_report.py
@@ -107,7 +107,7 @@ class PopulationFrameReport:
             return pd.DataFrame()
 
         res = pd.DataFrame(data=view.data,
-                           columns=pd.MultiIndex.from_arrays(np.asarray(view.ids).T),
+                           columns=pd.MultiIndex.from_arrays(np.asarray(view.ids, dtype="int64").T),
                            index=view.times).sort_index(axis=1)
 
         # rename from multi index to index cannot be achieved easily through df.rename

--- a/bluepysnap/nodes.py
+++ b/bluepysnap/nodes.py
@@ -545,22 +545,68 @@ class NodePopulation:
                 - ``mapping``: return the properties of nodes matching a properties filter.
                 - ``None``: return the properties of all nodes.
 
-            properties (list|str): If specified, return only the properties in the list.
+            properties (list|str|None): If specified, return only the properties in the list.
                 Otherwise return all properties.
 
         Returns:
             value/pandas.Series/pandas.DataFrame:
-                If a single node ID is passed as ``group`` and a single property as ``properties``,
-                returns a single value.
-                If a single node ID is passed as ``group`` and a list as ``properties``,
-                returns a pandas Series.
-                If something different from a single node ID is passed as ``group`` and a single
-                property as ``properties``, returns a pandas Series.
-                Otherwise, returns a pandas DataFrame indexed by node IDs.
+                The type of the returned object depends on the type of the input parameters,
+                see the Examples for an explanation of the different cases.
 
         Notes:
             The NodePopulation.property_names function will give you all the usable properties
             for the `properties` argument.
+
+        Examples:
+            Considering a node population composed by 3 nodes (0, 1, 2) and 12 properties,
+            the following examples show the types of the returned objects.
+
+            - If ``group`` is a single node ID and ``properties`` a single property,
+              returns a single scalar value.
+
+                >>> result = my_node_population.get(group=0, properties=Cell.MTYPE)
+                >>> type(result)
+                str
+
+            - If ``group`` is a single node ID and ``properties`` a list or None,
+              returns a pandas Series indexed by the properties.
+
+                >>> result = my_node_population.get(group=0)
+                >>> type(result), result.shape
+                (pandas.core.series.Series, (12,))
+
+                >>> result = my_node_population.get(group=0, properties=[Cell.MTYPE])
+                >>> type(result), result.shape
+                (pandas.core.series.Series, (1,))
+
+            - If ``group`` is anything other than a single node ID, and ``properties`` is a single
+              property, returns a pandas Series indexed by node IDs.
+
+                >>> result = my_node_population.get(properties=Cell.MTYPE)
+                >>> type(result), result.shape
+                (pandas.core.series.Series, (3,))
+
+                >>> result = my_node_population.get(group=[0], properties=Cell.MTYPE)
+                >>> type(result), result.shape
+                (pandas.core.series.Series, (1,))
+
+            - In all the other cases, returns a pandas DataFrame indexed by node IDs.
+
+                >>> result = my_node_population.get()
+                >>> type(result), result.shape
+                (pandas.core.frame.DataFrame, (3, 12))
+
+                >>> result = my_node_population.get(group=[0])
+                >>> type(result), result.shape
+                (pandas.core.frame.DataFrame, (1, 12))
+
+                >>> result = my_node_population.get(properties=[Cell.MTYPE])
+                >>> type(result), result.shape
+                (pandas.core.frame.DataFrame, (3, 1))
+
+                >>> result = my_node_population.get(group=[0], properties=[Cell.MTYPE])
+                >>> type(result), result.shape
+                (pandas.core.frame.DataFrame, (1, 1))
         """
         result = self._data
         if properties is not None:

--- a/bluepysnap/nodes.py
+++ b/bluepysnap/nodes.py
@@ -545,14 +545,18 @@ class NodePopulation:
                 - ``mapping``: return the properties of nodes matching a properties filter.
                 - ``None``: return the properties of all nodes.
 
-            properties (list): If specified, return only the properties in the list.
+            properties (list|str): If specified, return only the properties in the list.
                 Otherwise return all properties.
 
         Returns:
             value/pandas.Series/pandas.DataFrame:
-                If single node ID is passed as ``group`` and single property as properties returns
-                a single value. If single node ID is passed as ``group`` and list as property
-                returns a pandas Series. Otherwise return a pandas DataFrame indexed by node IDs.
+                If a single node ID is passed as ``group`` and a single property as ``properties``,
+                returns a single value.
+                If a single node ID is passed as ``group`` and a list as ``properties``,
+                returns a pandas Series.
+                If something different from a single node ID is passed as ``group`` and a single
+                property as ``properties``, returns a pandas Series.
+                Otherwise, returns a pandas DataFrame indexed by node IDs.
 
         Notes:
             The NodePopulation.property_names function will give you all the usable properties

--- a/bluepysnap/spike_report.py
+++ b/bluepysnap/spike_report.py
@@ -106,7 +106,7 @@ class PopulationSpikeReport:
 
         if not res:
             return pd.Series(data=[], index=pd.Index([], name="times"),
-                             name=series_name, dtype=np.float64)
+                             name=series_name, dtype=IDS_DTYPE)
 
         res = pd.DataFrame(data=res, columns=[series_name, "times"]).set_index("times")[series_name]
         if self._sorted_by != "by_time":

--- a/setup.py
+++ b/setup.py
@@ -80,9 +80,9 @@ setup(
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Operating System :: POSIX',
         'Topic :: Scientific/Engineering',
         'Topic :: Utilities',

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -234,7 +234,10 @@ class TestEdges:
             self.test_obj.get(properties=["other2", "unknown"])
 
         ids = CircuitEdgeIds.from_dict({"default": [0, 1, 2, 3], "default2": [0, 1, 2, 3]})
-        tested = self.test_obj.get(ids, None)
+        with pytest.deprecated_call(
+            match="Returning ids with get/properties is deprecated and will be removed in 1.0.0"
+        ):
+            tested = self.test_obj.get(ids, None)
         assert tested == ids
 
         tested = self.test_obj.get(ids, properties=self.test_obj.property_names)
@@ -283,11 +286,14 @@ class TestEdges:
         with pytest.deprecated_call():
             self.test_obj.get(ids)
 
-    def test_properties(self):
+    def test_properties_deprecated(self):
         ids = CircuitEdgeIds.from_dict({"default": [0, 1, 2, 3], "default2": [0, 1, 2, 3]})
-        pdt.assert_frame_equal(self.test_obj.properties(ids, properties=["other2", "@source_node"]),
-                               self.test_obj.get(ids, properties=["other2", "@source_node"]),
-                               check_exact=False)
+        with pytest.deprecated_call(
+            match="Edges.properties function is deprecated and will be removed in 1.0.0"
+        ):
+            tested = self.test_obj.properties(ids, properties=["other2", "@source_node"])
+        expected = self.test_obj.get(ids, properties=["other2", "@source_node"])
+        pdt.assert_frame_equal(tested, expected, check_exact=False)
 
     def test_afferent_nodes(self):
         assert self.test_obj.afferent_nodes(0) == CircuitNodeIds.from_arrays(["default"], [2])
@@ -783,12 +789,24 @@ class TestEdgePopulation:
         with pytest.raises(BluepySnapError):
             self.test_obj.get([0], 'no-such-property')
 
-    def test_properties(self):
+    def test_get_without_properties_deprecated(self):
+        edge_ids = [0, 1]
+        with pytest.deprecated_call(
+            match="Returning ids with get/properties is deprecated and will be removed in 1.0.0"
+        ):
+            actual = self.test_obj.get(edge_ids, None)
+        expected = np.asarray(edge_ids, dtype=np.int64)
+        npt.assert_equal(actual, expected)
+
+    def test_properties_deprecated(self):
         ids = [0, 1, 2, 3]
         properties = ["@target_node", "@source_node"]
-        pdt.assert_frame_equal(self.test_obj.properties(ids, properties=properties),
-                               self.test_obj.get(ids, properties=properties),
-                               check_exact=False)
+        with pytest.deprecated_call(
+            match="EdgePopulation.properties function is deprecated and will be removed in 1.0.0"
+        ):
+            actual = self.test_obj.properties(ids, properties=properties)
+        expected = self.test_obj.get(ids, properties=properties)
+        pdt.assert_frame_equal(actual, expected, check_exact=False)
 
     def test_get_all_edge_ids_types(self):
         assert self.test_obj.get(0, Synapse.PRE_GID).tolist() == [2]

--- a/tests/test_frame_report.py
+++ b/tests/test_frame_report.py
@@ -176,8 +176,8 @@ class TestPopulationCompartmentReport:
         self.test_obj = test_module.CompartmentReport(self.simulation, "section_report")["default"]
         timestamps = np.linspace(0, 0.9, 10)
         data = np.array([np.arange(7) + j * 0.1 for j in range(10)], dtype=np.float32)
-        ids = [(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1), (2, 1)]
-        self.df = pd.DataFrame(data=data, columns=pd.MultiIndex.from_tuples(ids), index=timestamps)
+        ids = np.array([[0, 0, 1, 1, 2, 2, 2], [0, 1, 0, 1, 0, 1, 1]], dtype="uint64")
+        self.df = pd.DataFrame(data=data, columns=pd.MultiIndex.from_arrays(ids), index=timestamps)
 
     def test__resolve(self):
         npt.assert_array_equal(self.test_obj._resolve({Cell.MTYPE: "L6_Y"}), [1, 2])
@@ -269,4 +269,5 @@ class TestPopulationSomaReport(TestPopulationCompartmentReport):
         self.test_obj = test_module.SomaReport(self.simulation, "soma_report")["default"]
         timestamps = np.linspace(0, 0.9, 10)
         data = {0: timestamps, 1: timestamps + 1, 2: timestamps + 2}
-        self.df = pd.DataFrame(data=data, index=timestamps, columns=[0, 1, 2]).astype(np.float32)
+        columns = np.array([0, 1, 2], dtype="uint64")
+        self.df = pd.DataFrame(data=data, index=timestamps, columns=columns).astype(np.float32)

--- a/tests/test_frame_report.py
+++ b/tests/test_frame_report.py
@@ -176,8 +176,8 @@ class TestPopulationCompartmentReport:
         self.test_obj = test_module.CompartmentReport(self.simulation, "section_report")["default"]
         timestamps = np.linspace(0, 0.9, 10)
         data = np.array([np.arange(7) + j * 0.1 for j in range(10)], dtype=np.float32)
-        ids = np.array([[0, 0, 1, 1, 2, 2, 2], [0, 1, 0, 1, 0, 1, 1]], dtype="uint64")
-        self.df = pd.DataFrame(data=data, columns=pd.MultiIndex.from_arrays(ids), index=timestamps)
+        ids = [(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1), (2, 1)]
+        self.df = pd.DataFrame(data=data, columns=pd.MultiIndex.from_tuples(ids), index=timestamps)
 
     def test__resolve(self):
         npt.assert_array_equal(self.test_obj._resolve({Cell.MTYPE: "L6_Y"}), [1, 2])
@@ -203,7 +203,7 @@ class TestPopulationCompartmentReport:
         pdt.assert_frame_equal(self.test_obj.get(CircuitNodeId("default", 2)), self.df.loc[:, [2]])
 
         # not from this population
-        pdt.assert_frame_equal(self.test_obj.get(CircuitNodeId("default2", 2)),  pd.DataFrame())
+        pdt.assert_frame_equal(self.test_obj.get(CircuitNodeId("default2", 2)), pd.DataFrame())
 
         pdt.assert_frame_equal(self.test_obj.get([2, 0]), self.df.loc[:, [0, 2]])
 
@@ -269,5 +269,4 @@ class TestPopulationSomaReport(TestPopulationCompartmentReport):
         self.test_obj = test_module.SomaReport(self.simulation, "soma_report")["default"]
         timestamps = np.linspace(0, 0.9, 10)
         data = {0: timestamps, 1: timestamps + 1, 2: timestamps + 2}
-        columns = np.array([0, 1, 2], dtype="uint64")
-        self.df = pd.DataFrame(data=data, index=timestamps, columns=columns).astype(np.float32)
+        self.df = pd.DataFrame(data=data, index=timestamps, columns=[0, 1, 2]).astype(np.float32)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -656,7 +656,9 @@ class TestNodePopulation:
         )
 
         assert _call("Node0_L6_Y", properties=[Cell.X, Cell.MTYPE, Cell.LAYER]).empty
-        assert _call(1, properties={Cell.MTYPE}).tolist() == ["L6_Y"]
+        assert _call(1, properties=[Cell.MTYPE]).tolist() == ["L6_Y"]
+        assert _call([1], properties=Cell.MTYPE).tolist() == ["L6_Y"]
+        assert _call([1, 2], properties=Cell.MTYPE).tolist() == ["L6_Y", "L6_Y"]
         with pytest.raises(BluepySnapError):
             _call(0, properties='no-such-property')
         with pytest.raises(BluepySnapError):

--- a/tests/test_spike_report.py
+++ b/tests/test_spike_report.py
@@ -21,7 +21,7 @@ def _create_series(node_ids, index, name="ids"):
         return pd.Index(ids, name="times")
     if len(node_ids) == 0:
         # removing warning
-        return pd.Series(node_ids, index=_get_index(index), name=name, dtype=np.float64)
+        return pd.Series(node_ids, index=_get_index(index), name=name, dtype=np.int64)
     return pd.Series(node_ids, index=_get_index(index), name=name)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,6 @@ def test_is_iterable():
 
 def test_is_node_id():
     assert test_module.is_node_id(1)
-    assert test_module.is_node_id(np.int(1))
     assert test_module.is_node_id(np.int32(1))
     assert test_module.is_node_id(np.uint32(1))
     assert test_module.is_node_id(np.int64(1))

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,12 @@ name = bluepysnap
 [tox]
 envlist =
     lint
-    py{37,38}
+    py{37,38,39}
 
 ignore_basepython_conflict = true
 
 [testenv]
-basepython=python3.8
+basepython=python3.9
 deps =
     mock
     pytest
@@ -57,4 +57,5 @@ convention = google
 [gh-actions]
 python =
   3.7: py37
-  3.8: py38, lint, docs
+  3.8: py38
+  3.9: py39, lint, docs


### PR DESCRIPTION
- Add python 3.9 tests.
- Ensure that ids in frame reports are always np.int64 even when using libsonata 0.1.10 (see NSETM-1766).
- Fix deprecation warnings.
