### PR TITLE
Add option to only print/return fatal errors in validation

### DIFF
--- a/bluepysnap/circuit_validation.py
+++ b/bluepysnap/circuit_validation.py
@@ -590,12 +590,14 @@ def validate_networks(config, skip_slow):
     return errors
 
 
-def validate(config_file, skip_slow, print_errors=True):
+def validate(config_file, skip_slow, only_errors=False, print_errors=True):
     """Validates Sonata circuit.
 
     Args:
         config_file (str): path to Sonata circuit config file official checks.
-        skip_slow(bool): skip slow tests
+        skip_slow (bool): skip slow tests
+        only_errors (bool): only return/print fatal errors
+        print_errors (bool): print errors
 
     Returns:
         list: List of errors, empty if no errors
@@ -605,6 +607,9 @@ def validate(config_file, skip_slow, print_errors=True):
 
     if "networks" in config:
         errors += validate_networks(config, skip_slow)
+
+    if only_errors:
+        errors = [e for e in errors if e.level == Error.FATAL]
 
     if print_errors:
         _print_errors(errors)

--- a/bluepysnap/cli.py
+++ b/bluepysnap/cli.py
@@ -28,7 +28,7 @@ def cli(verbose):
         "edge indices are correct, etc"
     ),
 )
-@click.option("--only-errors", is_flag=True, help=("Only print fatal errors (ignore warnings)"))
+@click.option("--only-errors", is_flag=True, help="Only print fatal errors (ignore warnings)")
 def validate(config_file, skip_slow, only_errors):
     """Validate of Sonata circuit based on config file.
 

--- a/bluepysnap/cli.py
+++ b/bluepysnap/cli.py
@@ -28,11 +28,13 @@ def cli(verbose):
         "edge indices are correct, etc"
     ),
 )
-def validate(config_file, skip_slow):
+@click.option("--only-errors", is_flag=True, help=("Only print fatal errors (ignore warnings)"))
+def validate(config_file, skip_slow, only_errors):
     """Validate of Sonata circuit based on config file.
 
     Args:
         config_file (str): path to Sonata circuit config file
-        skip_slow(bool): skip slow tests
+        skip_slow (bool): skip slow tests
+        only_errors (bool): only print fatal errors
     """
-    circuit_validation.validate(config_file, skip_slow)
+    circuit_validation.validate(config_file, skip_slow, only_errors)

--- a/tests/test_circuit_validation.py
+++ b/tests/test_circuit_validation.py
@@ -49,6 +49,23 @@ def test_skip_slow():
         patched.assert_not_called()
 
 
+def test_only_errors():
+    with patch(f"{test_module.__name__}.validate_networks") as patched:
+        patched.return_value = [
+            Error(Error.FATAL, "fatal_error"),
+            Error(Error.WARNING, "a mere warning"),
+            Error(Error.INFO, "utterly useful message"),
+        ]
+
+        errors = test_module.validate(
+            str(TEST_DATA_DIR / "circuit_config.json"),
+            skip_slow=True,
+            only_errors=True,
+        )
+        assert len(errors) == 1
+        assert all(e.level == Error.FATAL for e in errors)
+
+
 def test_print_errors(capsys):
     with copy_test_data() as (_, config_copy_path):
         with edit_config(config_copy_path) as config:

--- a/tests/test_circuit_validation.py
+++ b/tests/test_circuit_validation.py
@@ -63,7 +63,7 @@ def test_only_errors():
             only_errors=True,
         )
         assert len(errors) == 1
-        assert all(e.level == Error.FATAL for e in errors)
+        assert list(errors)[0] == Error(Error.FATAL, "fatal_error")
 
 
 def test_print_errors(capsys):


### PR DESCRIPTION
This is to ignore warnings and INFO messages (not currently used) raised diring the validation.

Also ignores the datatype warning messages raised during schema validation.