### PR TITLE
Access population config from the populations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Version v1.0.1
+--------------
+
+New Features
+~~~~~~~~~~~~
+- Access the population configs for node/edge populations via population_config property
+
 Version v1.0.0
 --------------
 

--- a/bluepysnap/circuit.py
+++ b/bluepysnap/circuit.py
@@ -49,6 +49,14 @@ class Circuit:
         """Network config dictionary."""
         return self._config.to_dict()
 
+    def get_node_population_config(self, name):
+        """Get node population configuration."""
+        return self._config.populations["node"].get(name, {})
+
+    def get_edge_population_config(self, name):
+        """Get edge population configuration."""
+        return self._config.populations["edge"].get(name, {})
+
     @cached_property
     def node_sets(self):
         """Returns the NodeSets object bound to the circuit."""

--- a/bluepysnap/circuit.py
+++ b/bluepysnap/circuit.py
@@ -21,6 +21,7 @@ from cached_property import cached_property
 
 from bluepysnap.config import CircuitConfig
 from bluepysnap.edges import Edges
+from bluepysnap.exceptions import BluepySnapError
 from bluepysnap.node_sets import NodeSets
 from bluepysnap.nodes import Nodes
 
@@ -51,11 +52,17 @@ class Circuit:
 
     def get_node_population_config(self, name):
         """Get node population configuration."""
-        return self._config.populations["node"].get(name, {})
+        try:
+            return self._config.populations["node"][name]
+        except KeyError as e:
+            raise BluepySnapError(f"Population config not found for node population: {name}") from e
 
     def get_edge_population_config(self, name):
         """Get edge population configuration."""
-        return self._config.populations["edge"].get(name, {})
+        try:
+            return self._config.populations["edge"][name]
+        except KeyError as e:
+            raise BluepySnapError(f"Population config not found for edge population: {name}") from e
 
     @cached_property
     def node_sets(self):

--- a/bluepysnap/circuit.py
+++ b/bluepysnap/circuit.py
@@ -53,14 +53,14 @@ class Circuit:
     def get_node_population_config(self, name):
         """Get node population configuration."""
         try:
-            return self._config.populations["node"][name]
+            return self._config.node_populations[name]
         except KeyError as e:
             raise BluepySnapError(f"Population config not found for node population: {name}") from e
 
     def get_edge_population_config(self, name):
         """Get edge population configuration."""
         try:
-            return self._config.populations["edge"][name]
+            return self._config.edge_populations[name]
         except KeyError as e:
             raise BluepySnapError(f"Population config not found for edge population: {name}") from e
 

--- a/bluepysnap/config.py
+++ b/bluepysnap/config.py
@@ -187,8 +187,9 @@ class CircuitConfig(Config):
         # components: null in the config
         config = self.to_dict()
         networks = config.get("networks") or {}
+        components = config.get("components") or {}
 
-        def resolve_network_populations(element_type, components):
+        def resolve_network_populations(element_type):
             populations = {}
             type_file_key = f"{element_type}_file"
             element_dicts = networks.get(element_type) or []
@@ -206,10 +207,9 @@ class CircuitConfig(Config):
 
             return populations
 
-        # 'components' is not extended to edges as it currently has no keys for edges.
         self._populations = {
-            "node": resolve_network_populations("nodes", config.get("components") or {}),
-            "edge": resolve_network_populations("edges", {}),
+            "node": resolve_network_populations("nodes"),
+            "edge": resolve_network_populations("edges"),
         }
 
 

--- a/bluepysnap/config.py
+++ b/bluepysnap/config.py
@@ -175,9 +175,15 @@ class CircuitConfig(Config):
         return cls(config_path, libsonata.CircuitConfig)
 
     @property
-    def populations(self):
-        """Access population configs."""
-        return self._populations
+    def node_populations(self):
+        """Access node population configs."""
+        return self._populations['nodes']
+
+    @property
+    def edge_populations(self):
+        """Access edge population configs."""
+        return self._populations['edges']
+
 
     # NOTE: These are parsed here to keep Parser returning the exact parsed configuration.
     def _resolve_population_configs(self):
@@ -205,8 +211,8 @@ class CircuitConfig(Config):
             return populations
 
         return {
-            "node": resolve_network_populations("nodes"),
-            "edge": resolve_network_populations("edges"),
+            "nodes": resolve_network_populations("nodes"),
+            "edges": resolve_network_populations("edges"),
         }
 
 

--- a/bluepysnap/config.py
+++ b/bluepysnap/config.py
@@ -167,7 +167,7 @@ class CircuitConfig(Config):
     def __init__(self, *args):
         """Initializes circuit config."""
         super().__init__(*args)
-        self._populations = self._resolve_population_configs()
+        self._populations = self._resolve_population_configs(self.to_dict())
 
     @classmethod
     def from_config(cls, config_path):
@@ -177,18 +177,18 @@ class CircuitConfig(Config):
     @property
     def node_populations(self):
         """Access node population configs."""
-        return self._populations['nodes']
+        return self._populations["nodes"]
 
     @property
     def edge_populations(self):
         """Access edge population configs."""
-        return self._populations['edges']
-
+        return self._populations["edges"]
 
     # NOTE: These are parsed here to keep Parser returning the exact parsed configuration.
-    def _resolve_population_configs(self):
+
+    @staticmethod
+    def _resolve_population_configs(config):
         """Resolves population configs for the node and edge populations."""
-        config = self.to_dict()
         networks = config.get("networks") or {}
         components = config.get("components") or {}
 

--- a/bluepysnap/config.py
+++ b/bluepysnap/config.py
@@ -184,7 +184,6 @@ class CircuitConfig(Config):
         """Access edge population configs."""
         return self._populations["edges"]
 
-
     @staticmethod
     def _resolve_population_configs(config):
         """Resolves population configs for the node and edge populations."""

--- a/bluepysnap/config.py
+++ b/bluepysnap/config.py
@@ -184,7 +184,6 @@ class CircuitConfig(Config):
         """Access edge population configs."""
         return self._populations["edges"]
 
-    # NOTE: These are parsed here to keep Parser returning the exact parsed configuration.
 
     @staticmethod
     def _resolve_population_configs(config):

--- a/bluepysnap/config.py
+++ b/bluepysnap/config.py
@@ -167,8 +167,7 @@ class CircuitConfig(Config):
     def __init__(self, *args):
         """Initializes circuit config."""
         super().__init__(*args)
-        self._populations = None
-        self._resolve_population_configs()
+        self._populations = self._resolve_population_configs()
 
     @classmethod
     def from_config(cls, config_path):
@@ -183,8 +182,6 @@ class CircuitConfig(Config):
     # NOTE: These are parsed here to keep Parser returning the exact parsed configuration.
     def _resolve_population_configs(self):
         """Resolves population configs for the node and edge populations."""
-        # All the "or"s exist to have empty dicts lists instead of None's to overcome issues like:
-        # components: null in the config
         config = self.to_dict()
         networks = config.get("networks") or {}
         components = config.get("components") or {}
@@ -207,7 +204,7 @@ class CircuitConfig(Config):
 
             return populations
 
-        self._populations = {
+        return {
             "node": resolve_network_populations("nodes"),
             "edge": resolve_network_populations("edges"),
         }

--- a/bluepysnap/edges.py
+++ b/bluepysnap/edges.py
@@ -118,7 +118,9 @@ class EdgePopulation:
     def population_config(self):
         """Access the configuration for the population.
 
-        This configuration is extended the filepath to the h5 file containing the population.
+        This configuration is extended with
+        * 'components' of the circuit config
+        * 'edges_file': the path the h5 file containing the population.
         """
         return self._circuit.get_edge_population_config(self.name)
 

--- a/bluepysnap/edges.py
+++ b/bluepysnap/edges.py
@@ -115,6 +115,14 @@ class EdgePopulation:
         return {Edge.SOURCE_NODE_ID, Edge.TARGET_NODE_ID}
 
     @property
+    def population_config(self):
+        """Access the configuration for the population.
+
+        This configuration is extended the filepath to the h5 file containing the population.
+        """
+        return self._circuit.get_edge_population_config(self.name)
+
+    @property
     def property_names(self):
         """Set of available edge properties.
 
@@ -450,6 +458,7 @@ class EdgePopulation:
 
     def _iter_connections(self, source_node_ids, target_node_ids, unique_node_ids, shuffle):
         """Iterate through `source_node_ids` -> `target_node_ids` connections."""
+
         # pylint: disable=too-many-branches,too-many-locals
         def _optimal_direction():
             """Choose between source and target node IDs for iterating."""
@@ -566,10 +575,10 @@ class EdgePopulation:
     @cached_property
     def h5_filepath(self):
         """Get the H5 edges file associated with population."""
-        for edge_conf in self._circuit.config["networks"]["edges"]:
-            if self.name in edge_conf["populations"]:
-                return edge_conf["edges_file"]
-        raise BluepySnapError(f"h5_filepath not found for population '{self.name}'")
+        try:
+            return self.population_config["edges_file"]
+        except KeyError as e:
+            raise BluepySnapError(f"h5_filepath not found for population '{self.name}'") from e
 
 
 class Edges(

--- a/bluepysnap/edges.py
+++ b/bluepysnap/edges.py
@@ -572,13 +572,10 @@ class EdgePopulation:
             omit_edge_count = lambda x: x[:2]
             return map(omit_edge_count, it)
 
-    @cached_property
+    @property
     def h5_filepath(self):
         """Get the H5 edges file associated with population."""
-        try:
-            return self.population_config["edges_file"]
-        except KeyError as e:
-            raise BluepySnapError(f"h5_filepath not found for population '{self.name}'") from e
+        return self.population_config["edges_file"]
 
 
 class Edges(

--- a/bluepysnap/nodes.py
+++ b/bluepysnap/nodes.py
@@ -131,8 +131,9 @@ class NodePopulation:
     def population_config(self):
         """Access the configuration for the population.
 
-        This configuration is extended with 'components' part of the config and the filepath
-        to the h5 file containing the population.
+        This configuration is extended with
+        * 'components' of the circuit config
+        * 'nodes_file': the path the h5 file containing the population.
         """
         return self._circuit.get_node_population_config(self.name)
 

--- a/bluepysnap/nodes.py
+++ b/bluepysnap/nodes.py
@@ -577,13 +577,10 @@ class NodePopulation:
 
         return NeuronModelsHelper(self._properties, self)
 
-    @cached_property
+    @property
     def h5_filepath(self):
         """Get the H5 nodes file associated with population."""
-        try:
-            return self.population_config["nodes_file"]
-        except KeyError as e:
-            raise BluepySnapError(f"h5_filepath not found for population '{self.name}'") from e
+        return self.population_config["nodes_file"]
 
 
 class Nodes(

--- a/bluepysnap/nodes.py
+++ b/bluepysnap/nodes.py
@@ -128,6 +128,15 @@ class NodePopulation:
         )
 
     @property
+    def population_config(self):
+        """Access the configuration for the population.
+
+        This configuration is extended with 'components' part of the config and the filepath
+        to the h5 file containing the population.
+        """
+        return self._circuit.get_node_population_config(self.name)
+
+    @property
     def property_names(self):
         """Set of available node properties.
 
@@ -571,10 +580,10 @@ class NodePopulation:
     @cached_property
     def h5_filepath(self):
         """Get the H5 nodes file associated with population."""
-        for node_conf in self._circuit.config["networks"]["nodes"]:
-            if self.name in node_conf["populations"]:
-                return node_conf["nodes_file"]
-        raise BluepySnapError(f"h5_filepath not found for population '{self.name}'")
+        try:
+            return self.population_config["nodes_file"]
+        except KeyError as e:
+            raise BluepySnapError(f"h5_filepath not found for population '{self.name}'") from e
 
 
 class Nodes(

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -5,6 +5,7 @@ from libsonata import SonataError
 
 import bluepysnap.circuit as test_module
 from bluepysnap.edges import EdgePopulation, Edges
+from bluepysnap.exceptions import BluepySnapError
 from bluepysnap.nodes import NodePopulation, Nodes
 
 from utils import TEST_DATA_DIR, copy_test_data, edit_config, skip_if_libsonata_0_1_16
@@ -27,6 +28,16 @@ def test_all():
     assert sorted(circuit.node_sets) == sorted(
         json.loads((TEST_DATA_DIR / "node_sets.json").read_text())
     )
+
+    fake_pop = "fake"
+    with pytest.raises(
+        BluepySnapError, match=f"Population config not found for node population: {fake_pop}"
+    ):
+        circuit.get_node_population_config(fake_pop)
+    with pytest.raises(
+        BluepySnapError, match=f"Population config not found for edge population: {fake_pop}"
+    ):
+        circuit.get_edge_population_config(fake_pop)
 
 
 @skip_if_libsonata_0_1_16

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -155,3 +155,48 @@ def test_simulation_config():
     )
     assert actual["conditions"]["celsius"] == 34.0
     assert actual["conditions"]["v_init"] == -80
+
+
+def test__resolve_population_configs():
+    node = {
+        "nodes_file": "nodes_path",
+        "populations": {"node_pop": {"changed_node": "changed", "added_this": "node_test"}},
+    }
+
+    edge = {
+        "edges_file": "edges_path",
+        "populations": {"edge_pop": {"changed_edge": "changed", "added_this": "edge_test"}},
+    }
+
+    config = {
+        "components": {
+            "unchanged": True,
+            "changed_node": "unchanged",
+            "changed_edge": "unchanged",
+        },
+        "networks": {
+            "nodes": [node],
+            "edges": [edge],
+        },
+    }
+    expected_node_pop = {
+        "unchanged": True,
+        "changed_node": "changed",
+        "changed_edge": "unchanged",
+        "added_this": "node_test",
+        "nodes_file": "nodes_path",
+    }
+    expected_edge_pop = {
+        "unchanged": True,
+        "changed_node": "unchanged",
+        "changed_edge": "changed",
+        "added_this": "edge_test",
+        "edges_file": "edges_path",
+    }
+    expected = {
+        "nodes": {"node_pop": expected_node_pop},
+        "edges": {"edge_pop": expected_edge_pop},
+    }
+    res = test_module.CircuitConfig._resolve_population_configs(config)
+
+    assert res == expected

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -1393,8 +1393,3 @@ class TestEdgePopulation:
 
     def test_h5_filepath_from_config(self):
         assert self.test_obj.h5_filepath == str(TEST_DATA_DIR / "edges.h5")
-
-    def test_no_h5_filepath(self):
-        with pytest.raises(BluepySnapError, match="h5_filepath not found for population"):
-            self.test_obj.name = "fake"
-            self.test_obj.h5_filepath

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -692,7 +692,6 @@ class TestEdges:
         )
 
     def test_pair_edges(self):
-
         # no connection between 0 and 2
         assert self.test_obj.pair_edges(0, 2, None) == CircuitEdgeIds.from_arrays([], [])
         actual = self.test_obj.pair_edges(0, 2, [Synapse.AXONAL_DELAY])

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -996,8 +996,3 @@ class TestNodePopulation:
 
     def test_h5_filepath_from_config(self):
         assert self.test_obj.h5_filepath == str(TEST_DATA_DIR / "nodes.h5")
-
-    def test_no_h5_filepath(self):
-        with pytest.raises(BluepySnapError, match="h5_filepath not found for population"):
-            self.test_obj.name = "fake"
-            self.test_obj.h5_filepath

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,8 @@ max-line-length = 100
 [pydocstyle]
 # ignore the following
 #   - D413: no blank line after last section
-add-ignore = D413
+#   - D202: no blank line after docstring (handled by black, causes an issue if first line is '#pylint:disable')
+add-ignore = D413,D202
 convention = google
 
 [gh-actions]


### PR DESCRIPTION
Added back the ability to access population config from the populations.
* also has the components
* also has nodes/edges file path to avoid having to loop for it in `nodes.py` / `edges.py`
