### PR TITLE
HOTFIX: omit dtypes when doing nodes.get or edges.get [NSETM-2112]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Version v1.0.1
+--------------
+
+Bug Fixes
+~~~~~~~~~
+- nodes.get, edges.get were throwing an incorrect "Same property with different dtype" Error
+
 Version v1.0.0
 --------------
 

--- a/bluepysnap/edges.py
+++ b/bluepysnap/edges.py
@@ -450,6 +450,7 @@ class EdgePopulation:
 
     def _iter_connections(self, source_node_ids, target_node_ids, unique_node_ids, shuffle):
         """Iterate through `source_node_ids` -> `target_node_ids` connections."""
+
         # pylint: disable=too-many-branches,too-many-locals
         def _optimal_direction():
             """Choose between source and target node IDs for iterating."""

--- a/bluepysnap/network.py
+++ b/bluepysnap/network.py
@@ -156,14 +156,8 @@ class NetworkObject(abc.ABC):
         if unknown_props:
             raise BluepySnapError(f"Unknown properties required: {unknown_props}")
 
-        # Retrieve the dtypes of the selected properties.
-        # However, the int dtype may not be preserved if some values are NaN.
-        dtypes = {
-            column: dtype
-            for column, dtype in self.property_dtypes.items()
-            if column in properties_set
-        }
-        dataframes = [pd.DataFrame(columns=properties, index=ids.index_schema).astype(dtypes)]
+        # TODO: add dtypes to the initial dataframe when a proper fix to the dtype issue is done
+        dataframes = [pd.DataFrame(columns=properties, index=ids.index_schema)]
         for name, pop in sorted(self.items()):
             # since ids is sorted, global_pop_ids should be sorted as well
             global_pop_ids = ids.filter_population(name)

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -289,6 +289,7 @@ class TestEdges:
         assert tested == expected
 
     def test_get(self):
+        # TODO: Remove all ", check_dtype=False" when a proper fix to the dtype issue is done
         with pytest.raises(BluepySnapError, match="You need to set edge_ids in get."):
             self.test_obj.get(properties=["other2"])
 
@@ -336,7 +337,7 @@ class TestEdges:
                 names=["population", "edge_ids"],
             ),
         )
-        pdt.assert_frame_equal(tested, expected)
+        pdt.assert_frame_equal(tested, expected, check_dtype=False)
 
         tested = self.test_obj.get(
             CircuitEdgeIds.from_dict({"default2": [0, 1, 2, 3]}),
@@ -359,7 +360,7 @@ class TestEdges:
                 names=["population", "edge_ids"],
             ),
         )
-        pdt.assert_frame_equal(tested, expected)
+        pdt.assert_frame_equal(tested, expected, check_dtype=False)
 
         with pytest.raises(KeyError, match="'default'"):
             tested.loc[("default", 0)]
@@ -384,7 +385,7 @@ class TestEdges:
                 names=["population", "edge_ids"],
             ),
         )
-        pdt.assert_frame_equal(tested, expected)
+        pdt.assert_frame_equal(tested, expected, check_dtype=False)
 
         tested = self.test_obj.get(ids, properties="@source_node")
         expected = pd.DataFrame(
@@ -405,7 +406,7 @@ class TestEdges:
                 names=["population", "edge_ids"],
             ),
         )
-        pdt.assert_frame_equal(tested, expected)
+        pdt.assert_frame_equal(tested, expected, check_dtype=False)
 
         tested = self.test_obj.get(ids, properties="other2")
         expected = pd.DataFrame(
@@ -692,7 +693,6 @@ class TestEdges:
         )
 
     def test_pair_edges(self):
-
         # no connection between 0 and 2
         assert self.test_obj.pair_edges(0, 2, None) == CircuitEdgeIds.from_arrays([], [])
         actual = self.test_obj.pair_edges(0, 2, [Synapse.AXONAL_DELAY])

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -291,6 +291,7 @@ class TestNodes:
         assert tested == expected
 
     def test_get(self):
+        # TODO: Remove all ", check_dtype=False" when a proper fix to the dtype issue is done
         # return all properties for all the ids
         tested = self.test_obj.get()
         assert tested.shape == (self.test_obj.size, len(self.test_obj.property_names))
@@ -326,7 +327,7 @@ class TestNodes:
                 names=["population", "node_ids"],
             ),
         )
-        pdt.assert_frame_equal(tested, expected)
+        pdt.assert_frame_equal(tested, expected, check_dtype=False)
 
         tested = self.test_obj.get(
             group={"population": "default2"}, properties=["other2", "other1", "layer"]
@@ -347,7 +348,7 @@ class TestNodes:
                 names=["population", "node_ids"],
             ),
         )
-        pdt.assert_frame_equal(tested, expected)
+        pdt.assert_frame_equal(tested, expected, check_dtype=False)
 
         with pytest.raises(KeyError, match="'default'"):
             tested.loc[("default", 0)]
@@ -370,7 +371,7 @@ class TestNodes:
                 names=["population", "node_ids"],
             ),
         )
-        pdt.assert_frame_equal(tested, expected)
+        pdt.assert_frame_equal(tested, expected, check_dtype=False)
 
         tested = self.test_obj.get(properties="layer")
         expected = pd.DataFrame(
@@ -390,7 +391,7 @@ class TestNodes:
                 names=["population", "node_ids"],
             ),
         )
-        pdt.assert_frame_equal(tested, expected)
+        pdt.assert_frame_equal(tested, expected, check_dtype=False)
 
         tested = self.test_obj.get(properties="other2")
         expected = pd.DataFrame(

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,8 @@ max-line-length = 100
 [pydocstyle]
 # ignore the following
 #   - D413: no blank line after last section
-add-ignore = D413
+#   - D202: no blank line after docstring (handled by black, causes an issue if first line is '#pylint:disable')
+add-ignore = D413,D202
 convention = google
 
 [gh-actions]


### PR DESCRIPTION
This is a temporary (as if) fix to the "Same property with different dtype" error. 

Need to figure how to fix this while still keeping the efficiency of @GianlucaFicarelli 's optimisations. It is possible to merge categories of catecorigals but it seems it's not as straightforward as we'd hope.

So to have the get functions working. We should go with this for now, release 1.0.1 and add a proper fix when someone has time to work on this.