### PR TITLE
Add python 3.10 tests, and update GitHub actions

### DIFF
--- a/.github/workflows/publish-sdist.yml
+++ b/.github/workflows/publish-sdist.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Build a source tarball
         run:
             python setup.py sdist

--- a/.github/workflows/publish-sdist.yml
+++ b/.github/workflows/publish-sdist.yml
@@ -10,17 +10,17 @@ jobs:
     name: Build and publish on PyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Build a source tarball
         run:
             python setup.py sdist
 
       - name: Publish distribution package to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -28,10 +28,10 @@ jobs:
       run: |
         tox
     - name: Upload to codecov
-      if: ${{matrix.python-version == '3.9'}}
-      uses: codecov/codecov-action@v1
+      if: ${{matrix.python-version == '3.10'}}
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: false
         files: ./coverage.xml
         flags: pytest
-        name: "bluepysnap-py39"
+        name: "bluepysnap-py310"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version v1.0.5
+--------------
+
+Improvements
+~~~~~~~~~~~~
+- Add python 3.10 tests, and update GitHub actions.
+
+
 Version v1.0.4
 --------------
 

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: POSIX",
         "Topic :: Scientific/Engineering",
         "Topic :: Utilities",

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,12 @@ name = bluepysnap
 [tox]
 envlist =
     lint
-    py{37,38,39}
+    py{37,38,39,310}
 
 ignore_basepython_conflict = true
 
 [testenv]
-basepython=python3.9
+basepython=python3.10
 deps =
     pytest
     pytest-cov
@@ -71,4 +71,5 @@ convention = google
 python =
   3.7: py37
   3.8: py38
-  3.9: py39, lint, docs
+  3.9: py39
+  3.10: py310, lint, docs


### PR DESCRIPTION
GitHub actions have been updated to avoid the deprecation:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
