### PR TITLE
Added intersection() method to circuit ids

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 Version v1.0.7
 --------------
 
+New Features
+~~~~~~~~~~~~
+- Added ``CircuitIds.intersection`` to select the intersection of two
+
 Bug Fixes
 ~~~~~~~~~
 - Fix CircuitIds.sample() to always return different samples.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Version v1.0.7
 
 New Features
 ~~~~~~~~~~~~
-- Added ``CircuitIds.intersection`` to select the intersection of two
+- Added ``CircuitIds.intersection`` to take the intersection of two ``CircuitIds``.
 
 Bug Fixes
 ~~~~~~~~~

--- a/bluepysnap/circuit_ids.py
+++ b/bluepysnap/circuit_ids.py
@@ -263,11 +263,7 @@ class CircuitIds(abc.ABC):
             circuit_ids (CircuitIds): The CircuitIds to intersect with.
             inplace (bool): if set to True, do the transformation inplace.
         """
-
-        def _intersection(index):
-            return index.intersection(circuit_ids.index)
-
-        return self._apply(_intersection, inplace)
+        return self._apply(lambda x: x.intersection(circuit_ids.index), inplace)
 
     def to_csv(self, filepath):
         """Save CircuitIds to csv format."""

--- a/bluepysnap/circuit_ids.py
+++ b/bluepysnap/circuit_ids.py
@@ -258,8 +258,7 @@ class CircuitIds(abc.ABC):
 
         Notes:
             This function returns a CircuitIDs which contains only those ids which are in both
-            the this CircuitNodeIDs and the provided CircuitIDs. The index of the resulting
-            CircuitNodeIDs will be sorted.
+            this CircuitIds and the provided CircuitIds. The index of the result will be sorted.
 
         Args:
             ids: The other CircuitNodeIDs

--- a/bluepysnap/circuit_ids.py
+++ b/bluepysnap/circuit_ids.py
@@ -256,18 +256,16 @@ class CircuitIds(abc.ABC):
     def intersection(self, circuit_ids, inplace=False):
         """Take the intersection of this CircuitIds and the input.
 
-        Notes:
-            The index of the result is sorted.
+        The index of the resulting object is sorted if ``inplace=False``.
+        Otherwise, the orginal order of the index is kept.
 
         Args:
             circuit_ids (CircuitIds): The CircuitIds to intersect with.
             inplace (bool): if set to True, do the transformation inplace.
         """
-        ids = set(circuit_ids.tolist())
 
-        def _intersection(ind):
-            res = ids.intersection(set(ind))
-            return self.from_tuples((*res,), sort_index=True).index
+        def _intersection(index):
+            return index.intersection(circuit_ids.index)
 
         return self._apply(_intersection, inplace)
 

--- a/bluepysnap/circuit_ids.py
+++ b/bluepysnap/circuit_ids.py
@@ -253,6 +253,26 @@ class CircuitIds(abc.ABC):
         """
         return self._apply(lambda x: x.unique(), inplace)
 
+    def intersection(self, ids, inplace=False):
+        """Take the intersection of this CircuitIDs with another.
+
+        Notes:
+            This function returns a CircuitIDs which contains only those ids which are in both
+            the this CircuitNodeIDs and the provided CircuitIDs. The index of the resulting
+            CircuitNodeIDs will be sorted.
+
+        Args:
+            ids: The other CircuitNodeIDs
+            inplace: if True, modify this CircuitNodeIDs
+        """
+        tuples_other = set(ids.tolist())
+        def _intersect(ind):
+            tuples_self = set(ind)
+            intersected = tuples_self.intersection(tuples_other)
+            return self.from_tuples(list(intersected), sort_index=True).index
+
+        return self._apply(_intersect, inplace)
+    
     def to_csv(self, filepath):
         """Save CircuitIds to csv format."""
         self.index.to_frame(index=False).to_csv(filepath, index=False)

--- a/bluepysnap/circuit_ids.py
+++ b/bluepysnap/circuit_ids.py
@@ -266,13 +266,14 @@ class CircuitIds(abc.ABC):
             inplace: if True, modify this CircuitNodeIDs
         """
         tuples_other = set(ids.tolist())
+
         def _intersect(ind):
             tuples_self = set(ind)
             intersected = tuples_self.intersection(tuples_other)
             return self.from_tuples(list(intersected), sort_index=True).index
 
         return self._apply(_intersect, inplace)
-    
+
     def to_csv(self, filepath):
         """Save CircuitIds to csv format."""
         self.index.to_frame(index=False).to_csv(filepath, index=False)

--- a/bluepysnap/circuit_ids.py
+++ b/bluepysnap/circuit_ids.py
@@ -253,25 +253,23 @@ class CircuitIds(abc.ABC):
         """
         return self._apply(lambda x: x.unique(), inplace)
 
-    def intersection(self, ids, inplace=False):
-        """Take the intersection of this CircuitIDs with another.
+    def intersection(self, circuit_ids, inplace=False):
+        """Take the intersection of this CircuitIds and the input.
 
         Notes:
-            This function returns a CircuitIDs which contains only those ids which are in both
-            this CircuitIds and the provided CircuitIds. The index of the result will be sorted.
+            The index of the result is sorted.
 
         Args:
-            ids: The other CircuitNodeIDs
-            inplace: if True, modify this CircuitNodeIDs
+            circuit_ids (CircuitIds): The CircuitIds to intersect with.
+            inplace (bool): if set to True, do the transformation inplace.
         """
-        tuples_other = set(ids.tolist())
+        ids = set(circuit_ids.tolist())
 
-        def _intersect(ind):
-            tuples_self = set(ind)
-            intersected = tuples_self.intersection(tuples_other)
-            return self.from_tuples(list(intersected), sort_index=True).index
+        def _intersection(ind):
+            res = ids.intersection(set(ind))
+            return self.from_tuples((*res,), sort_index=True).index
 
-        return self._apply(_intersect, inplace)
+        return self._apply(_intersection, inplace)
 
     def to_csv(self, filepath):
         """Save CircuitIds to csv format."""

--- a/tests/test_circuit_ids.py
+++ b/tests/test_circuit_ids.py
@@ -80,7 +80,7 @@ class TestCircuitNodeIds:
             self.ids_cls(1)
 
         assert isinstance(self.test_obj_sorted, self.ids_cls)
-        
+
     def test_from_arrays(self):
         tested = self.ids_cls.from_arrays(["a", "b"], [0, 1])
         pdt.assert_index_equal(tested.index, self._circuit_ids(["a", "b"], [0, 1]))
@@ -210,10 +210,9 @@ class TestCircuitNodeIds:
         assert test_obj == expected
 
     def test_intersection(self):
-        first_ids = self.ids_cls.from_tuples(
-            [('a', 1), ('a', 2), ('a', 1), ('a', 2), ('b', 1)])
-        to_intersect = self.ids_cls.from_tuples([('b', 1), ('a', 3), ('a', 2)])
-        expected = self.ids_cls.from_tuples([('a', 2), ('b', 1)])
+        first_ids = self.ids_cls.from_tuples([("a", 1), ("a", 2), ("a", 1), ("a", 2), ("b", 1)])
+        to_intersect = self.ids_cls.from_tuples([("b", 1), ("a", 3), ("a", 2)])
+        expected = self.ids_cls.from_tuples([("a", 2), ("b", 1)])
         print(first_ids, first_ids.intersection(to_intersect))
         assert first_ids.intersection(to_intersect) == expected
         assert first_ids != expected

--- a/tests/test_circuit_ids.py
+++ b/tests/test_circuit_ids.py
@@ -210,15 +210,21 @@ class TestCircuitNodeIds:
         assert test_obj == expected
 
     def test_intersection(self):
-        test_obj = self.ids_cls.from_tuples(_multi_index())
-        other = self.ids_cls.from_tuples([("b", 0), ("a", 3), ("a", 2)])
+        test_obj = self.ids_cls.from_tuples(_multi_index(), sort_index=False)
+        other = self.ids_cls.from_tuples([("b", 0), ("a", 3), ("a", 2)], sort_index=False)
         expected = self.ids_cls.from_tuples([("a", 2), ("b", 0)])
+        res = test_obj.intersection(other)
 
-        assert test_obj.intersection(other) == expected
+        # res should be sorted when inplace=False
+        assert res == expected
         assert test_obj != expected
 
-        test_obj.intersection(other, inplace=True)
-        assert test_obj == expected
+        res = test_obj.intersection(other, inplace=True)
+        assert res is None
+
+        # test_obj index should not be sorted when inplace=True
+        assert test_obj != expected
+        assert all(expected.index == test_obj.index.sort_values())
 
     def test_sample(self):
         with patch("numpy.random.choice", return_value=np.array([0, 3])):

--- a/tests/test_circuit_ids.py
+++ b/tests/test_circuit_ids.py
@@ -80,7 +80,7 @@ class TestCircuitNodeIds:
             self.ids_cls(1)
 
         assert isinstance(self.test_obj_sorted, self.ids_cls)
-
+        
     def test_from_arrays(self):
         tested = self.ids_cls.from_arrays(["a", "b"], [0, 1])
         pdt.assert_index_equal(tested.index, self._circuit_ids(["a", "b"], [0, 1]))
@@ -208,6 +208,17 @@ class TestCircuitNodeIds:
             self._circuit_ids(["a", "a", "b", "a", "c", "b", "c"], [0, 1, 0, 2, 0, 5, 1])
         )
         assert test_obj == expected
+
+    def test_intersection(self):
+        first_ids = self.ids_cls.from_tuples(
+            [('a', 1), ('a', 2), ('a', 1), ('a', 2), ('b', 1)])
+        to_intersect = self.ids_cls.from_tuples([('b', 1), ('a', 3), ('a', 2)])
+        expected = self.ids_cls.from_tuples([('a', 2), ('b', 1)])
+        print(first_ids, first_ids.intersection(to_intersect))
+        assert first_ids.intersection(to_intersect) == expected
+        assert first_ids != expected
+        first_ids.intersection(to_intersect, inplace=True)
+        assert first_ids == expected
 
     def test_sample(self):
         with patch("numpy.random.choice", return_value=np.array([0, 3])):

--- a/tests/test_circuit_ids.py
+++ b/tests/test_circuit_ids.py
@@ -210,14 +210,15 @@ class TestCircuitNodeIds:
         assert test_obj == expected
 
     def test_intersection(self):
-        first_ids = self.ids_cls.from_tuples([("a", 1), ("a", 2), ("a", 1), ("a", 2), ("b", 1)])
-        to_intersect = self.ids_cls.from_tuples([("b", 1), ("a", 3), ("a", 2)])
-        expected = self.ids_cls.from_tuples([("a", 2), ("b", 1)])
-        print(first_ids, first_ids.intersection(to_intersect))
-        assert first_ids.intersection(to_intersect) == expected
-        assert first_ids != expected
-        first_ids.intersection(to_intersect, inplace=True)
-        assert first_ids == expected
+        test_obj = self.ids_cls.from_tuples(_multi_index())
+        other = self.ids_cls.from_tuples([("b", 0), ("a", 3), ("a", 2)])
+        expected = self.ids_cls.from_tuples([("a", 2), ("b", 0)])
+
+        assert test_obj.intersection(other) == expected
+        assert test_obj != expected
+
+        test_obj.intersection(other, inplace=True)
+        assert test_obj == expected
 
     def test_sample(self):
         with patch("numpy.random.choice", return_value=np.array([0, 3])):


### PR DESCRIPTION
`np.intersect1d(ids, other_ids)` was a really common tool in the bluepy.v2 days . 
This is intended to replace that operation for bluepysnap.
It gets a CircuitIds object which has only those ids in both the calling object and the passed object.