### PR TITLE
Reduced the node's selection before getting properties

### DIFF
--- a/bluepysnap/nodes/node_population.py
+++ b/bluepysnap/nodes/node_population.py
@@ -442,11 +442,6 @@ class NodePopulation:
                 (pandas.core.frame.DataFrame, (1, 1))
         """
         result = self._data
-        if properties is not None:
-            for p in utils.ensure_list(properties):
-                self._check_property(p)
-            result = result[properties]
-
         if group is not None:
             if isinstance(group, (int, np.integer)):
                 self._check_id(group)
@@ -455,6 +450,11 @@ class NodePopulation:
             else:
                 group = self.ids(group)
             result = result.loc[group]
+
+        if properties is not None:
+            for p in utils.ensure_list(properties):
+                self._check_property(p)
+            result = result[properties]
 
         return result
 

--- a/tests/test_edges/test_edge_population.py
+++ b/tests/test_edges/test_edge_population.py
@@ -655,7 +655,7 @@ class TestEdgePopulation:
         with open(pickle_path, "rb") as fd:
             edge_population = pickle.load(fd)
 
-        assert pickle_path.stat().st_size < 250
+        assert pickle_path.stat().st_size <= 250
         assert edge_population.name == "default"
 
 

--- a/tests/test_edges/test_edges.py
+++ b/tests/test_edges/test_edges.py
@@ -784,5 +784,5 @@ class TestEdges:
         with open(pickle_path, "rb") as fd:
             test_obj = pickle.load(fd)
 
-        assert pickle_path.stat().st_size < 150
+        assert pickle_path.stat().st_size < 170
         assert test_obj.size == 8

--- a/tests/test_nodes/test_node_population.py
+++ b/tests/test_nodes/test_node_population.py
@@ -633,7 +633,7 @@ class TestNodePopulation:
         with open(pickle_path, "rb") as fd:
             test_obj = pickle.load(fd)
 
-        assert pickle_path.stat().st_size < 190
+        assert pickle_path.stat().st_size <= 200
         assert test_obj.size == 3
 
 

--- a/tests/test_nodes/test_nodes.py
+++ b/tests/test_nodes/test_nodes.py
@@ -426,5 +426,5 @@ class TestNodes:
         with open(pickle_path, "rb") as fd:
             test_obj = pickle.load(fd)
 
-        assert pickle_path.stat().st_size < 150
+        assert pickle_path.stat().st_size < 170
         assert test_obj.size == 7


### PR DESCRIPTION
Reduced the node's selection before getting properties

* fixes https://github.com/BlueBrain/snap/issues/195
* much faster; hat tip @matz-e for noticing the problem