### PR TITLE
Index of the output of NodePopulation.get now has a name.

### DIFF
--- a/bluepysnap/nodes/node_population.py
+++ b/bluepysnap/nodes/node_population.py
@@ -100,7 +100,7 @@ class NodePopulation:
         categoricals = nodes.enumeration_names
 
         _all = nodes.select_all()
-        result = pd.DataFrame(index=pd.RangeIndex(_all.flat_size))
+        result = pd.DataFrame(index=pd.RangeIndex(_all.flat_size, name="node_ids"))
 
         for attr in sorted(nodes.attribute_names):
             if attr in categoricals:

--- a/tests/test_nodes/test_node_population.py
+++ b/tests/test_nodes/test_node_population.py
@@ -341,7 +341,7 @@ class TestNodePopulation:
                     [301.0, "L6_Y", 0.3],
                 ],
                 columns=[Cell.X, Cell.MTYPE, Cell.HOLDING_CURRENT],
-                index=[1, 2],
+                index=pd.Index([1, 2], name="node_ids"),
             ),
         )
 
@@ -357,7 +357,7 @@ class TestNodePopulation:
                     [301.0, "L6_Y", 0.3],
                 ],
                 columns=[Cell.X, Cell.MTYPE, Cell.HOLDING_CURRENT],
-                index=[1, 2],
+                index=pd.Index([1, 2], name="node_ids"),
             ),
         )
 
@@ -373,7 +373,7 @@ class TestNodePopulation:
                     [301.0, "L6_Y", 0.3],
                 ],
                 columns=[Cell.X, Cell.MTYPE, Cell.HOLDING_CURRENT],
-                index=[1, 2],
+                index=pd.Index([1, 2], name="node_ids"),
             ),
         )
 
@@ -385,7 +385,7 @@ class TestNodePopulation:
                     [301.0, "L6_Y", 6],
                 ],
                 columns=[Cell.X, Cell.MTYPE, Cell.LAYER],
-                index=[1, 2],
+                index=pd.Index([1, 2], name="node_ids"),
             ),
         )
 
@@ -438,7 +438,7 @@ class TestNodePopulation:
                     [301.0, 302.0, 303.0],
                     [101.0, 102.0, 103.0],
                 ],
-                index=[2, 0],
+                index=pd.Index([2, 0], name="node_ids"),
                 columns=[Cell.X, Cell.Y, Cell.Z],
             ),
         )
@@ -484,7 +484,7 @@ class TestNodePopulation:
                         ]
                     ),
                 ],
-                index=[2, 0, 1],
+                index=pd.Index([2, 0, 1], name="node_ids"),
                 name="orientation",
             ),
         )
@@ -519,7 +519,8 @@ class TestNodePopulation:
 
         pdt.assert_series_equal(
             _call_no_rot([2, 0, 1]),
-            pd.Series([np.eye(3), np.eye(3), np.eye(3)], index=[2, 0, 1], name="orientation"),
+            pd.Series([np.eye(3), np.eye(3), np.eye(3)], index=pd.Index([2, 0, 1], name="node_ids"),
+                      name="orientation"),
         )
 
         # NodePopulation with quaternions
@@ -567,7 +568,7 @@ class TestNodePopulation:
                         ]
                     ),
                 ],
-                index=[2, 0, 1],
+                index=pd.Index([2, 0, 1], name="node_ids"),
                 name="orientation",
             ),
         )

--- a/tests/test_nodes/test_node_population.py
+++ b/tests/test_nodes/test_node_population.py
@@ -519,8 +519,11 @@ class TestNodePopulation:
 
         pdt.assert_series_equal(
             _call_no_rot([2, 0, 1]),
-            pd.Series([np.eye(3), np.eye(3), np.eye(3)], index=pd.Index([2, 0, 1], name="node_ids"),
-                      name="orientation"),
+            pd.Series(
+                [np.eye(3), np.eye(3), np.eye(3)],
+                index=pd.Index([2, 0, 1], name="node_ids"),
+                name="orientation",
+            ),
         )
 
         # NodePopulation with quaternions


### PR DESCRIPTION
The naming of the index was introduced for consistency with the output of Nodes.get(). The later returns a DataFrame with a MultiIndex with named levels.

Suppose `circ` is a Circuit.
`nrn1 = circ.nodes.get()`
`nrn2 = circ.nodes["my_population"].get()`

Before, if I do:
`nrn1.reset_index()`
the node ids of the neurons are in a column called "node_ids". While:
`nrn2.reset_index()`
the node ids are in a column called "index".

This is inconsistent in my opinion. I fixed it by naming the index explicitly "node_ids".

Ideally, that specific string would be imported from bluepysnap/circuit_ids.py. To do that I would have to edit that file slightly, as currently the string is implicitly defined in line 283 of that file.