### PR TITLE
Use RangeIndex in nodes dataframe and improve _check_id

### DIFF
--- a/bluepysnap/nodes/node_population.py
+++ b/bluepysnap/nodes/node_population.py
@@ -100,7 +100,7 @@ class NodePopulation:
         categoricals = nodes.enumeration_names
 
         _all = nodes.select_all()
-        result = pd.DataFrame(index=np.arange(_all.flat_size))
+        result = pd.DataFrame(index=pd.RangeIndex(_all.flat_size))
 
         for attr in sorted(nodes.attribute_names):
             if attr in categoricals:
@@ -240,7 +240,7 @@ class NodePopulation:
 
     def _check_id(self, node_id):
         """Check that single node ID belongs to the circuit."""
-        if node_id not in self._data.index:
+        if node_id < 0 or node_id >= len(self._data.index):
             raise BluepySnapError(f"node ID not found: {node_id} in population '{self.name}'")
 
     def _check_ids(self, node_ids):
@@ -254,9 +254,9 @@ class NodePopulation:
         else:
             max_id = max(node_ids)
             min_id = min(node_ids)
-        if min_id < 0 or max_id >= self._data.index.shape[0]:
+        if min_id < 0 or max_id >= len(self._data.index):
             raise BluepySnapError(
-                f"All node IDs must be >= 0 and < {self._data.index.shape[0]} "
+                f"All node IDs must be >= 0 and < {len(self._data.index)} "
                 f"for population '{self.name}'"
             )
 


### PR DESCRIPTION
If the index is a regular index, when accessing df.loc[x] for the first time (when x is an array, and not an integer), Pandas calls the cached property Index.is_unique, that can take a few seconds with big dataframes:

Using a RangeIndex solves the issue, because is_unique is always True.

https://github.com/pandas-dev/pandas/blob/37ea63d540fd27274cad6585082c91b1283f963d/pandas/core/indexes/base.py#L2206

Using the performance_improvements branch:
```python
In [1]: import random
   ...: import bluepysnap
   ...: 
   ...: random.seed(0)
   ...: path = "/gpfs/bbp.cscs.ch/project/proj30/tickets/BLPY-289_improve_get/circuit/circuit_config.json"
   ...: c = bluepysnap.Circuit(path)
   ...: nodes = c.nodes["root__neurons"]
   ...: node_ids = [random.randrange(nodes.size) for _ in range(100)]
   ...: 

In [2]: %time df1 = nodes.get()
   ...: %time df2 = nodes.get(node_ids)
   ...: 
CPU times: user 1.62 s, sys: 2.4 s, total: 4.02 s
Wall time: 4.44 s
CPU times: user 41 ms, sys: 110 ms, total: 151 ms
Wall time: 151 ms
```

Using the master branch:
```python
In [1]: import random
   ...: import bluepysnap
   ...: 
   ...: random.seed(0)
   ...: path = "/gpfs/bbp.cscs.ch/project/proj30/tickets/BLPY-289_improve_get/circuit/circuit_config.json"
   ...: c = bluepysnap.Circuit(path)
   ...: nodes = c.nodes["root__neurons"]
   ...: node_ids = [random.randrange(nodes.size) for _ in range(100)]
   ...: 

In [2]: %time df1 = nodes.get()
   ...: %time df2 = nodes.get(node_ids)
   ...: 
CPU times: user 1.63 s, sys: 2.61 s, total: 4.24 s
Wall time: 5.15 s
CPU times: user 4.94 s, sys: 431 ms, total: 5.37 s
Wall time: 5.37 s
```

Executing the script from BLPY-289/NSETM-2181 with the performance_improvements branch.
Requesting single ids in a loop:
```
python try_get.py snap single 100
Loaded cells with bluepysnap, version 1.0.6.dev4+g82485de.d20230509 [6.145 seconds]
Single mode [0.090 seconds]

python try_get.py snap joined 100
Loaded cells with bluepysnap, version 1.0.6.dev4+g82485de.d20230509 [6.534 seconds]
Joined mode [0.120 seconds]
```
and requesting a list of ids
```
python try_get.py snap single_once 100
Loaded cells with bluepysnap, version 1.0.6.dev4+g82485de.d20230509 [6.307 seconds]
Single mode [0.179 seconds]

python try_get.py snap joined_once 100
Loaded cells with bluepysnap, version 1.0.6.dev4+g82485de.d20230509 [6.410 seconds]
Joined mode [0.192 seconds]
```
So now all the 4 results are similar as it should be expected (previously, the last 2 were taking around 5 seconds instead of 0.179 and 0.192)