### PR TITLE
Cache properties accessing libsonata methods

### DIFF
--- a/bluepysnap/edges/edge_population.py
+++ b/bluepysnap/edges/edge_population.py
@@ -60,12 +60,20 @@ class EdgePopulation:
         self._circuit = circuit
         self.name = population_name
 
-    @property
+    @cached_property
     def _properties(self):
+        """Edge population properties.
+
+        Cached for some performance improvement when it's accessed several times.
+        """
         return self._circuit.to_libsonata.edge_population_properties(self.name)
 
-    @property
+    @cached_property
     def _population(self):
+        """Libsonata edge population.
+
+        Cached for some performance improvement when it's accessed several times.
+        """
         return self._circuit.to_libsonata.edge_population(self.name)
 
     @staticmethod
@@ -590,10 +598,9 @@ class EdgePopulation:
                 )
             ) from e
 
-        properties = self._circuit.to_libsonata.edge_population_properties(self.name)
-        if not properties.spatial_synapse_index_dir:
+        if not self._properties.spatial_synapse_index_dir:
             raise BluepySnapError(f"It appears {self.name} does not have synapse indices")
-        return open_index(properties.spatial_synapse_index_dir)
+        return open_index(self._properties.spatial_synapse_index_dir)
 
     def __getstate__(self):
         """Make EdgePopulation pickle-able, without storing state of caches."""

--- a/bluepysnap/edges/edge_population.py
+++ b/bluepysnap/edges/edge_population.py
@@ -60,19 +60,19 @@ class EdgePopulation:
         self._circuit = circuit
         self.name = population_name
 
-    @cached_property
+    @property
     def _properties(self):
         """Edge population properties.
 
-        Cached for some performance improvement when it's accessed several times.
+        Not cached because quick enough, but do not call in heavy loops.
         """
         return self._circuit.to_libsonata.edge_population_properties(self.name)
 
-    @cached_property
+    @property
     def _population(self):
         """Libsonata edge population.
 
-        Cached for some performance improvement when it's accessed several times.
+        Not cached because it would keep the hdf5 file open.
         """
         return self._circuit.to_libsonata.edge_population(self.name)
 
@@ -598,9 +598,10 @@ class EdgePopulation:
                 )
             ) from e
 
-        if not self._properties.spatial_synapse_index_dir:
+        index_dir = self._properties.spatial_synapse_index_dir
+        if not index_dir:
             raise BluepySnapError(f"It appears {self.name} does not have synapse indices")
-        return open_index(self._properties.spatial_synapse_index_dir)
+        return open_index(index_dir)
 
     def __getstate__(self):
         """Make EdgePopulation pickle-able, without storing state of caches."""

--- a/bluepysnap/edges/edge_population.py
+++ b/bluepysnap/edges/edge_population.py
@@ -60,12 +60,9 @@ class EdgePopulation:
         self._circuit = circuit
         self.name = population_name
 
-    @property
+    @cached_property
     def _properties(self):
-        """Edge population properties.
-
-        Not cached because quick enough, but do not call in heavy loops.
-        """
+        """Edge population properties."""
         return self._circuit.to_libsonata.edge_population_properties(self.name)
 
     @property

--- a/bluepysnap/nodes/node_population.py
+++ b/bluepysnap/nodes/node_population.py
@@ -188,12 +188,20 @@ class NodePopulation:
                 result.insert(n + loc, name, values)
         return result
 
-    @property
+    @cached_property
     def _properties(self):
+        """Node population properties.
+
+        Cached for some performance improvement when it's accessed several times.
+        """
         return self._circuit.to_libsonata.node_population_properties(self.name)
 
-    @property
+    @cached_property
     def _population(self):
+        """Libsonata node population.
+
+        Cached for some performance improvement when it's accessed several times.
+        """
         return self._circuit.to_libsonata.node_population(self.name)
 
     @cached_property
@@ -665,12 +673,10 @@ class NodePopulation:
                 )
             ) from e
 
-        properties = self._circuit.to_libsonata.node_population_properties(self.name)
-
-        if not properties.spatial_segment_index_dir:
+        if not self._properties.spatial_segment_index_dir:
             raise BluepySnapError(f"It appears {self.name} does not have segment indices")
 
-        return open_index(properties.spatial_segment_index_dir)
+        return open_index(self._properties.spatial_segment_index_dir)
 
     def __getstate__(self):
         """Make NodePopulation pickle-able, without storing state of caches."""

--- a/bluepysnap/nodes/node_population.py
+++ b/bluepysnap/nodes/node_population.py
@@ -188,12 +188,9 @@ class NodePopulation:
                 result.insert(n + loc, name, values)
         return result
 
-    @property
+    @cached_property
     def _properties(self):
-        """Node population properties.
-
-        Not cached because quick enough, but do not call in heavy loops.
-        """
+        """Node population properties."""
         return self._circuit.to_libsonata.node_population_properties(self.name)
 
     @property

--- a/bluepysnap/nodes/node_population.py
+++ b/bluepysnap/nodes/node_population.py
@@ -188,19 +188,19 @@ class NodePopulation:
                 result.insert(n + loc, name, values)
         return result
 
-    @cached_property
+    @property
     def _properties(self):
         """Node population properties.
 
-        Cached for some performance improvement when it's accessed several times.
+        Not cached because quick enough, but do not call in heavy loops.
         """
         return self._circuit.to_libsonata.node_population_properties(self.name)
 
-    @cached_property
+    @property
     def _population(self):
         """Libsonata node population.
 
-        Cached for some performance improvement when it's accessed several times.
+        Not cached because it would keep the hdf5 file open.
         """
         return self._circuit.to_libsonata.node_population(self.name)
 
@@ -673,10 +673,10 @@ class NodePopulation:
                 )
             ) from e
 
-        if not self._properties.spatial_segment_index_dir:
+        index_dir = self._properties.spatial_segment_index_dir
+        if not index_dir:
             raise BluepySnapError(f"It appears {self.name} does not have segment indices")
-
-        return open_index(self._properties.spatial_segment_index_dir)
+        return open_index(index_dir)
 
     def __getstate__(self):
         """Make NodePopulation pickle-able, without storing state of caches."""


### PR DESCRIPTION
If nodes and edges `_population` and `_properties` are accessed several times, there can be a small performance improvement if they are cached.

For a given circuit, the returned objects should always be the same, and the memory occupation should be minimal compared to the circuit data, so caching them shouldn't be an issue.

Some basic tests:
```python
import bluepysnap
path = "/gpfs/bbp.cscs.ch/project/proj30/tickets/BLPY-289_improve_get/circuit/circuit_config.json"
c = bluepysnap.Circuit(path)
nodes = c.nodes["root__neurons"]

%time nodes._population
%time nodes._properties
%time for i in range(1000): nodes._population
%time for i in range(1000): nodes._properties
```

Results @master:
```
CPU times: user 1.45 ms, sys: 0 ns, total: 1.45 ms
Wall time: 1.48 ms
CPU times: user 7 µs, sys: 13 µs, total: 20 µs
Wall time: 23.1 µs
CPU times: user 156 ms, sys: 105 ms, total: 260 ms
Wall time: 266 ms
CPU times: user 1.64 ms, sys: 0 ns, total: 1.64 ms
Wall time: 1.65 ms
```

Results @more_cached_properties
```
CPU times: user 841 µs, sys: 632 µs, total: 1.47 ms
Wall time: 1.5 ms
CPU times: user 14 µs, sys: 24 µs, total: 38 µs
Wall time: 42.4 µs
CPU times: user 77 µs, sys: 0 ns, total: 77 µs
Wall time: 81.3 µs
CPU times: user 78 µs, sys: 0 ns, total: 78 µs
Wall time: 80.8 µs
```
