### PR TITLE
Drop python 3.7 support

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Improvements
 - Publish version as ``bluepysnap.__version__``
 - Support lazy loading of nodes attributes.
 - Add python 3.11 tests.
+- Drop python 3.7 support.
 
 Version v1.0.5
 --------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length  =  100
 target-version  =  [
-    'py37',
+    'py38',
 ]
 include  =  '(bluepysnap|tests)\/.*\.py|doc\/source\/conf\.py|setup\.py'
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ with open("README.rst") as f:
 
 setup(
     name="bluepysnap",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "cached_property>=1.0",
         "h5py>=3.0.1,<4.0.0",
@@ -85,7 +85,6 @@ setup(
     keywords=["SONATA", "BlueBrainProject"],
     classifiers=[
         "Development Status :: 3 - Alpha",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -9,7 +9,7 @@ from bluepysnap.edges import EdgePopulation, Edges
 from bluepysnap.exceptions import BluepySnapError
 from bluepysnap.nodes import NodePopulation, Nodes
 
-from utils import TEST_DATA_DIR, copy_test_data, edit_config, skip_if_libsonata_0_1_16
+from utils import TEST_DATA_DIR, copy_test_data, edit_config
 
 
 def test_all():
@@ -44,7 +44,6 @@ def test_all():
         circuit.get_edge_population_config(fake_pop)
 
 
-@skip_if_libsonata_0_1_16
 def test_duplicate_node_populations():
     with copy_test_data() as (_, config_path):
         with edit_config(config_path) as config:
@@ -55,7 +54,6 @@ def test_duplicate_node_populations():
             test_module.Circuit(config_path)
 
 
-@skip_if_libsonata_0_1_16
 def test_duplicate_edge_populations():
     with copy_test_data() as (_, config_path):
         with edit_config(config_path) as config:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,10 +17,6 @@ from bluepysnap.nodes import NodePopulation, Nodes
 TEST_DIR = Path(__file__).resolve().parent
 TEST_DATA_DIR = TEST_DIR / "data"
 
-skip_if_libsonata_0_1_16 = pytest.mark.skipif(
-    libsonata.version == "0.1.16", reason="Disabled with libsonata 0.1.16"
-)
-
 
 @contextmanager
 def setup_tempdir(cleanup=True):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ name = bluepysnap
 [tox]
 envlist =
     lint
-    py{37,38,39,310,311}
+    py{38,39,310,311}
 
 ignore_basepython_conflict = true
 
@@ -69,7 +69,6 @@ convention = google
 
 [gh-actions]
 python =
-  3.7: py37
   3.8: py38
   3.9: py39
   3.10: py310


### PR DESCRIPTION
The end of life of python 3.7 is close, and libsonata wheels for python 3.7 have been removed.
Since it's not possible to test python 3.7 without compiling libsonata, we can remove py37 tests and set python 3.8 as the minimum tested and supported version as it's done in this PR.

Alternatively, we could compile libsonata during py37 tests, and postpone the removal of python 3.7 support.