### PR TITLE
Improve performance when querying a population with get() and ids()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Improvements
 - Publish version as ``bluepysnap.__version__``
 - Support lazy loading of nodes attributes.
 - Add t_step parameter to frame reports.
+- Improve query performance in get() and ids().
 - Add python 3.11 tests.
 - Drop python 3.7 support.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Bug Fixes
 ~~~~~~~~~
 - Fix CircuitIds.sample() to always return different samples.
 - Ensure that the report DataFrames have the same schema even when empty.
-
+- Improve performance when querying a population with get() and ids().
 
 Version v1.0.6
 --------------
@@ -19,7 +19,6 @@ Improvements
 - Publish version as ``bluepysnap.__version__``
 - Support lazy loading of nodes attributes.
 - Add t_step parameter to frame reports.
-- Improve query performance in get() and ids().
 - Add python 3.11 tests.
 - Drop python 3.7 support.
 

--- a/bluepysnap/query.py
+++ b/bluepysnap/query.py
@@ -71,7 +71,7 @@ def _complex_query(prop, query):
     result = True
     for key, value in query.items():
         if key == REGEX_KEY:
-            result = _logical_and([result, prop.str.match(value + "\\Z")])
+            result = _logical_and([result, prop.str.match(value + r"\Z")])
         else:
             raise BluepySnapError(f"Unknown query modifier: '{key}'")
     return result

--- a/bluepysnap/query.py
+++ b/bluepysnap/query.py
@@ -28,17 +28,20 @@ def _logical_and(masks):
         masks: list of array-like, or booleans.
 
     Returns:
-        the resulting mask as a numpy array, or a bool. Return True if the masks list is empty.
+        the resulting mask as a numpy array, or a bool.
+        Return True if the masks list is empty, similarly to all([]).
     """
-    # filter out True masks (as bool)
-    masks = [m for m in masks if m is not True]
-    if any(m is False for m in masks):
-        return False
-    if len(masks) == 0:
+    filtered_masks = []
+    for mask in masks:
+        if mask is False:
+            return False
+        if mask is True:
+            continue
+        filtered_masks.append(mask)
+    if not filtered_masks:
         return True
-    masks = (np.asarray(m, dtype=bool) for m in masks)
-    # faster than np.logical_and.reduce or np.all
-    return reduce(operator.and_, masks)
+    # reduce(operator.and_, masks) is faster than np.logical_and.reduce() or np.all()
+    return reduce(operator.and_, (np.asarray(m, dtype=bool) for m in filtered_masks))
 
 
 def _logical_or(masks):
@@ -48,17 +51,20 @@ def _logical_or(masks):
         masks: list of array-like, or booleans.
 
     Returns:
-        the resulting mask as a numpy array, or a bool. Return False if the masks list is empty.
+        the resulting mask as a numpy array, or a bool.
+        Return False if the masks list is empty, similarly to any([]).
     """
-    # filter out False masks (as bool)
-    masks = [m for m in masks if m is not False]
-    if any(m is True for m in masks):
-        return True
-    if len(masks) == 0:
+    filtered_masks = []
+    for mask in masks:
+        if mask is True:
+            return True
+        if mask is False:
+            continue
+        filtered_masks.append(mask)
+    if not filtered_masks:
         return False
-    masks = (np.asarray(m, dtype=bool) for m in masks)
-    # faster than np.logical_or.reduce or np.any
-    return reduce(operator.or_, masks)
+    # reduce(operator.or_, masks) is faster than np.logical_or.reduce() or np.any()
+    return reduce(operator.or_, (np.asarray(m, dtype=bool) for m in filtered_masks))
 
 
 def _complex_query(prop, query):

--- a/bluepysnap/query.py
+++ b/bluepysnap/query.py
@@ -78,8 +78,10 @@ def _properties_mask(data, population_name, queries):
             prop_mask = np.logical_and(prop >= v1, prop <= v2)
         elif isinstance(values, Mapping):
             prop_mask = _complex_query(prop, values)
+        elif isinstance(values, list):
+            prop_mask = prop.isin(values)
         else:
-            prop_mask = np.in1d(prop, values)
+            prop_mask = prop == values
         mask = np.logical_and(mask, prop_mask)
     return mask
 

--- a/tests/test_nodes/test_nodes.py
+++ b/tests/test_nodes/test_nodes.py
@@ -204,6 +204,9 @@ class TestNodes:
         # Mapping --> CircuitNodeIds query on the populations empty dict return all
         assert self.test_obj.ids({}) == self.test_obj.ids()
 
+        assert self.test_obj.ids({"$and": []}) == self.test_obj.ids()
+        assert self.test_obj.ids({"$or": []}) == CircuitNodeIds.from_dict({})
+
         # Mapping --> CircuitNodeIds query on the populations
         tested = self.test_obj.ids({"layer": 2})
         expected = CircuitNodeIds.from_arrays(["default", "default2"], [0, 3])

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -54,6 +54,8 @@ def test_resolve_ids():
     assert [True, False, True] == resolve_ids(
         data, "", {"$or": [{"node_id": 0}, {"edge_id": 2}]}
     ).tolist()
+    assert [False, False, False] == resolve_ids(data, "", {"$or": []}).tolist()
+    assert [True, True, True] == resolve_ids(data, "", {"$and": []}).tolist()
 
     with pytest.raises(BluepySnapError) as e:
         resolve_ids(data, "", {"str": {"$regex": "*.some", "edge_id": 2}})


### PR DESCRIPTION
Main improvements:
- use pandas series when the type is category, instead of converting to numpy arrays of objects
- avoid creating full numpy arrays of True or False
- quickly return when False or True is found in masks, if possible

See NSETM-2181 for more details.
