### PR TITLE
Ensure that the report DataFrames have the same schema even when empty

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Version v1.0.7
 Bug Fixes
 ~~~~~~~~~
 - Fix CircuitIds.sample() to always return different samples.
+- Ensure that the report DataFrames have the same schema even when empty.
 
 
 Version v1.0.6

--- a/bluepysnap/frame_report.py
+++ b/bluepysnap/frame_report.py
@@ -24,7 +24,7 @@ from libsonata import ElementReportReader, SonataError
 
 import bluepysnap._plotting
 from bluepysnap.exceptions import BluepySnapError
-from bluepysnap.utils import ensure_ids, ensure_list
+from bluepysnap.utils import ensure_ids
 
 L = logging.getLogger(__name__)
 
@@ -104,9 +104,6 @@ class PopulationFrameReport:
         except SonataError as e:
             raise BluepySnapError(e) from e
 
-        if len(view.ids) == 0:
-            return pd.DataFrame()
-
         # cell ids and section ids in the columns are enforced to be int64
         # to avoid issues with numpy automatic conversions and to ensure that
         # the results are the same regardless of the libsonata version [NSETM-1766]
@@ -163,21 +160,15 @@ class FilteredFrameReport:
                 - (population_name, node_id, compartment id) for the CompartmentReport
                 - (population_name, node_id) for the SomaReport
         """
-        res = pd.DataFrame()
+        dataframes = {}
         for population in self.frame_report.population_names:
             frames = self.frame_report[population]
-            try:
-                ids = frames.nodes.ids(group=self.group)
-            except BluepySnapError:
-                continue
+            ids = frames.nodes.ids(group=self.group, raise_missing_property=False)
             data = frames.get(group=ids, t_start=self.t_start, t_stop=self.t_stop)
-            if data.empty:
-                continue
-            new_index = tuple(tuple([population] + ensure_list(x)) for x in data.columns)
-            data.columns = pd.MultiIndex.from_tuples(new_index)
-            # need to do this in order to preserve MultiIndex for columns
-            res = data if res.empty else data.join(res, how="outer")
-        return res.sort_index().sort_index(axis=1)
+            dataframes[population] = data
+        # preserve MultiIndex for columns, adding a population level
+        result = pd.concat(dataframes.values(), axis=1, keys=dataframes.keys())
+        return result.sort_index(axis=0).sort_index(axis=1)
 
     # pylint: disable=protected-access
     trace = bluepysnap._plotting.frame_trace


### PR DESCRIPTION
When the report returns empty data, an empty pd.DataFrame() was returned.
However, for consistency, with this PR it always return a DataFrame with the same schema (for example, if the columns are MultiIndex, they should still be MultiIndex).