### PR TITLE
Add query key `population_type`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version v3.0.1
+--------------
+
+New Features
+~~~~~~~~~~~~
+- Added the possibility to query Edge IDs and Node IDs based on edge/node population type using query key ``population_type``
+
+
 Version v3.0.0
 --------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ New Features
 ~~~~~~~~~~~~
 - Added the possibility to query Edge IDs and Node IDs based on edge/node population type using query key ``population_type``
 
+  - the types conform to `node types <https://sonata-extension.readthedocs.io/en/latest/sonata_config.html#populations>`_ and `edge types <https://sonata-extension.readthedocs.io/en/latest/sonata_config.html#id4>`_ defined in the sonata specification
+
 
 Version v3.0.0
 --------------

--- a/bluepysnap/edges/edge_population.py
+++ b/bluepysnap/edges/edge_population.py
@@ -232,7 +232,7 @@ class EdgePopulation:
         chunk_size = int(1e8)
         for chunk in np.array_split(ids, 1 + len(ids) // chunk_size):
             data = self.get(chunk, properties - unknown_props)
-            res.extend(chunk[query.resolve_ids(data, self.name, queries)])
+            res.extend(chunk[query.resolve_ids(data, self.name, self.type, queries)])
         return np.array(res, dtype=IDS_DTYPE)
 
     def ids(self, group=None, limit=None, sample=None, raise_missing_property=True):

--- a/bluepysnap/nodes/node_population.py
+++ b/bluepysnap/nodes/node_population.py
@@ -371,7 +371,7 @@ class NodePopulation:
             self._check_properties(properties)
         # load all the properties needed to execute the query, excluding the unknown properties
         data = self._get_data(properties & self.property_names)
-        idx = query.resolve_ids(data, self.name, queries)
+        idx = query.resolve_ids(data, self.name, self.type, queries)
         return idx.nonzero()[0]
 
     def ids(self, group=None, limit=None, sample=None, raise_missing_property=True):

--- a/bluepysnap/nodes/node_population.py
+++ b/bluepysnap/nodes/node_population.py
@@ -48,6 +48,8 @@ Examples:
     >>> nodes.ids(group={ Node.LAYER: 2})  # returns list of IDs matching layer==2
     >>> nodes.ids(group={ Node.LAYER: [2, 3]})  # returns list of IDs with layer in [2,3]
     >>> nodes.ids(group={ Node.X: (0, 1)})  # returns list of IDs with 0 < x < 1
+    >>> # returns list of IDs of biophysical node populations
+    >>> nodes.ids(group={ "population_type": "biophysical"})
     >>> # returns list of IDs matching one of the queries inside the 'or' list
     >>> nodes.ids(group={'$or': [{ Node.LAYER: [2, 3]},
     >>>                          { Node.X: (0, 1), Node.MTYPE: 'L1_SLAC' }]})

--- a/bluepysnap/query.py
+++ b/bluepysnap/query.py
@@ -101,6 +101,8 @@ def _positional_mask(data, ids):
         return True
     if isinstance(ids, int):
         ids = [ids]
+    elif len(ids) == 0:
+        return False
     mask = np.full(len(data), fill_value=False)
     indices = data.index.get_indexer(ids)
     mask[indices[indices > -1]] = True

--- a/bluepysnap/query.py
+++ b/bluepysnap/query.py
@@ -111,9 +111,9 @@ def _circuit_mask(data, population_name, population_type, queries):
     """Handle the population, node ID queries."""
     populations = queries.pop(POPULATION_KEY, None)
     types = queries.pop(POPULATION_TYPE_KEY, None)
-    if populations is not None and population_name not in set(utils.ensure_list(populations)):
+    if populations is not None and population_name not in utils.ensure_list(populations):
         ids = []
-    elif types is not None and population_type not in set(utils.ensure_list(types)):
+    elif types is not None and population_type not in utils.ensure_list(types):
         ids = []
     else:
         ids = queries.pop(NODE_ID_KEY, queries.pop(EDGE_ID_KEY, None))

--- a/bluepysnap/query.py
+++ b/bluepysnap/query.py
@@ -14,12 +14,21 @@ from bluepysnap.exceptions import BluepySnapError
 NODE_ID_KEY = "node_id"
 EDGE_ID_KEY = "edge_id"
 POPULATION_KEY = "population"
+POPULATION_TYPE_KEY = "population_type"
 OR_KEY = "$or"
 AND_KEY = "$and"
 REGEX_KEY = "$regex"
 NODE_SET_KEY = "$node_set"
 VALUE_KEYS = {REGEX_KEY}
-ALL_KEYS = {NODE_ID_KEY, EDGE_ID_KEY, POPULATION_KEY, OR_KEY, AND_KEY, NODE_SET_KEY} | VALUE_KEYS
+ALL_KEYS = {
+    NODE_ID_KEY,
+    EDGE_ID_KEY,
+    POPULATION_KEY,
+    POPULATION_TYPE_KEY,
+    OR_KEY,
+    AND_KEY,
+    NODE_SET_KEY,
+} | VALUE_KEYS
 
 
 def _logical_and(masks):
@@ -98,23 +107,26 @@ def _positional_mask(data, ids):
     return mask
 
 
-def _circuit_mask(data, population_name, queries):
+def _circuit_mask(data, population_name, population_type, queries):
     """Handle the population, node ID queries."""
     populations = queries.pop(POPULATION_KEY, None)
+    types = queries.pop(POPULATION_TYPE_KEY, None)
     if populations is not None and population_name not in set(utils.ensure_list(populations)):
+        ids = []
+    elif types is not None and population_type not in set(utils.ensure_list(types)):
         ids = []
     else:
         ids = queries.pop(NODE_ID_KEY, queries.pop(EDGE_ID_KEY, None))
     return queries, _positional_mask(data, ids)
 
 
-def _properties_mask(data, population_name, queries):
+def _properties_mask(data, population_name, population_type, queries):
     """Return mask of IDs matching `props` dict."""
     unknown_props = set(queries) - set(data.columns) - ALL_KEYS
     if unknown_props:
         return False
 
-    queries, mask = _circuit_mask(data, population_name, queries)
+    queries, mask = _circuit_mask(data, population_name, population_type, queries)
     if mask is False or isinstance(mask, np.ndarray) and not mask.any():
         # Avoid fail and/or processing time if wrong population or no nodes
         return False
@@ -202,7 +214,7 @@ def resolve_nodesets(node_sets, population, queries, raise_missing_prop):
     return resolved_queries
 
 
-def resolve_ids(data, population_name, queries):
+def resolve_ids(data, population_name, population_type, queries):
     """Returns an index mask of `data` for given `queries`.
 
     Args:
@@ -229,7 +241,7 @@ def resolve_ids(data, population_name, queries):
             queries[queries_key] = _logical_and(children_mask)
         else:
             queries[queries_key] = _properties_mask(
-                data, population_name, {queries_key: queries[queries_key]}
+                data, population_name, population_type, {queries_key: queries[queries_key]}
             )
 
     queries = deepcopy(queries)

--- a/bluepysnap/query.py
+++ b/bluepysnap/query.py
@@ -220,6 +220,7 @@ def resolve_ids(data, population_name, population_type, queries):
     Args:
         data (pd.DataFrame): data
         population_name (str): population name of `data`
+        population_type (str): population type
         queries (dict): queries
 
     Returns:

--- a/doc/source/notebooks/09_node_queries.ipynb
+++ b/doc/source/notebooks/09_node_queries.ipynb
@@ -147,6 +147,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "On top of these, a query can also be based on `node_id` or the `population_type`.\n",
+    "\n",
     "When the query is a `dict` and there is a `list` in the query, it is (usually) considered as an \"OR\" condition, and the keys of the query are considered as an \"AND\" condition. E.g.,\n",
     "```python\n",
     "circuit.nodes.ids({                    # give me the ids of nodes that\n",
@@ -402,6 +404,145 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Querying with population type\n",
+    "We can query nodes (or edges) based on their population type as specified in the [SONATA circuit configuration file](https://sonata-extension.readthedocs.io/en/latest/sonata_config.html).\n",
+    "\n",
+    "Let's find all the source nodes of projections (i.e., `virtual` nodes):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>model_template</th>\n",
+       "      <th>model_type</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>population</th>\n",
+       "      <th>node_ids</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">CorticoThalamic_projections</th>\n",
+       "      <th>0</th>\n",
+       "      <td></td>\n",
+       "      <td>virtual</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td></td>\n",
+       "      <td>virtual</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td></td>\n",
+       "      <td>virtual</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td></td>\n",
+       "      <td>virtual</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td></td>\n",
+       "      <td>virtual</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">MedialLemniscus_projections</th>\n",
+       "      <th>5018</th>\n",
+       "      <td></td>\n",
+       "      <td>virtual</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5019</th>\n",
+       "      <td></td>\n",
+       "      <td>virtual</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5020</th>\n",
+       "      <td></td>\n",
+       "      <td>virtual</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5021</th>\n",
+       "      <td></td>\n",
+       "      <td>virtual</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5022</th>\n",
+       "      <td></td>\n",
+       "      <td>virtual</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>88443 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                     model_template model_type\n",
+       "population                  node_ids                          \n",
+       "CorticoThalamic_projections 0                          virtual\n",
+       "                            1                          virtual\n",
+       "                            2                          virtual\n",
+       "                            3                          virtual\n",
+       "                            4                          virtual\n",
+       "...                                             ...        ...\n",
+       "MedialLemniscus_projections 5018                       virtual\n",
+       "                            5019                       virtual\n",
+       "                            5020                       virtual\n",
+       "                            5021                       virtual\n",
+       "                            5022                       virtual\n",
+       "\n",
+       "[88443 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result = circuit.nodes.get({'population_type': ['virtual']})\n",
+    "pd.concat([df for _,df in result])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Querying with regex\n",
     "We can use regex to query data (e.g., to cover \"OR\" cases) by using the key `$regex` and specify an expression as a `str`. For example, let's search `thalamus_neurons` by `mtypes` that start with `VPL`:\n",
     "\n"
@@ -409,7 +550,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -508,7 +649,7 @@
        "[65198 rows x 1 columns]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -532,7 +673,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -562,7 +703,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -583,7 +724,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -684,7 +825,7 @@
        "28381     135.235031  517.312378  428.180695"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -710,7 +851,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -740,7 +881,7 @@
        "           names=['population', 'node_ids'], length=35567)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -769,7 +910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {

--- a/doc/source/notebooks/10_edge_queries.ipynb
+++ b/doc/source/notebooks/10_edge_queries.ipynb
@@ -736,7 +736,7 @@
     "\n",
     "We already know that we can get any of the edge properties with `get` and and use any of the properties to filter which edges will be returned so we'll not cover that here. However, more often than not, that is not how we query edges. Most of the time, we want to find edges that connect certain nodes (or node sets) or want to find which nodes are connected to certain pre-synaptic (or post-synaptic) cells.\n",
     "\n",
-    "In the examples, we'll be using a single node population, but they work the same with `circuit.edges`, too.\n",
+    "In the examples, we'll be using a single edge population, but they work the same with `circuit.edges`, too.\n",
     "\n",
     "### Edges connecting cells with known ids\n",
     "\n",
@@ -1298,11 +1298,159 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So in short: each of these functions can have queries as parameters instead of the node ids.\n",
+    "\n",
+    "### Finding edges based on their type\n",
+    "Same as with the nodes, we can also query edges based on their `population_type`. \n",
+    "\n",
+    "Let's see how we can get the `chemical` synapses:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CircuitEdgeIds([('CorticoThalamic_projections__thalamus_neurons__chemical', 0),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', 1),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', 2),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', 3),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', 4),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', 0),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', 1),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', 2),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', 3),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', 4),\n",
+       "            (           'thalamus_neurons__thalamus_neurons__chemical', 0),\n",
+       "            (           'thalamus_neurons__thalamus_neurons__chemical', 1),\n",
+       "            (           'thalamus_neurons__thalamus_neurons__chemical', 2),\n",
+       "            (           'thalamus_neurons__thalamus_neurons__chemical', 3),\n",
+       "            (           'thalamus_neurons__thalamus_neurons__chemical', 4)],\n",
+       "           names=['population', 'edge_ids'])"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "circuit.edges.get({'population_type':'chemical',\n",
+    "                   'edge_id': [*range(5)]}) # Since the number of edges is massive, we only query a fraction of all the `edge_id`s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### _\"Cool beans... but... wait a minute! Why does it also return the projections?\"_\n",
+    "Indeed. Projections are also chemical synapses and they share the same population type, so defining `chemical` as the type also returns the projections. \n",
+    "\n",
+    "#### _I see. How do I get **only** the projections?\"_\n",
+    "You can use the population names to query only projections, but there is also way to get only projections without specifying the population names by taking advantage of the fact that the source node type of projections is `virtual` and the target node type is `biophysical`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CircuitEdgeIds([('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ...\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...)],\n",
+       "           names=['population', 'edge_ids'], length=18147635)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "circuit.edges.pathway_edges({'population_type': 'virtual'}, {'population_type': 'biophysical'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case, the same can be achieved by only defining the source nodes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CircuitEdgeIds([('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('CorticoThalamic_projections__thalamus_neurons__chemical', ...),\n",
+       "            ...\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...),\n",
+       "            ('MedialLemniscus_projections__thalamus_neurons__chemical', ...)],\n",
+       "           names=['population', 'edge_ids'], length=18147635)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "circuit.edges.efferent_edges({'population_type': 'virtual'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
-    "So in short: each of these functions can have queries as parameters instead of the node ids.\n",
+    "Please note, however, that also `neuromodulatory` edges use `virtual` source nodes, so if these type of edges are present in the circuit, those will also be returned by `efferent_edges`.\n",
     "\n",
     "## Conclusion\n",
     "In this notebook, we learned all the different queries related to edges: how to find connecting nodes/edges, how to query for the properties we're interested in, etc. We also learned about the differences between querying nodes and querying edges and the reasons behind the differences. \n",

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -15,7 +15,7 @@ from bluepysnap.circuit_ids_types import IDS_DTYPE, CircuitNodeId
 from bluepysnap.exceptions import BluepySnapError
 from bluepysnap.node_sets import NodeSets
 
-from utils import PICKLED_SIZE_ADJUSTMENT, TEST_DATA_DIR
+from utils import PICKLED_SIZE_ADJUSTMENT, TEST_DATA_DIR, copy_test_data, edit_config
 
 
 class TestNodes:
@@ -235,6 +235,31 @@ class TestNodes:
         expected = CircuitNodeIds.from_dict({"default": [0, 1, 2], "default2": [0]})
         assert tested == expected
 
+        # Test querying with the population type
+        with copy_test_data() as (_, config_path):
+            with edit_config(config_path) as config:
+                config["networks"]["nodes"][0]["populations"]["default"]["type"] = "virtual"
+
+            circuit = Circuit(config_path)
+
+            tested = circuit.nodes.ids({"population_type": "virtual"})
+            expected = CircuitNodeIds.from_arrays(3 * ["default"], [0, 1, 2])
+            assert tested == expected
+
+            tested = circuit.nodes.ids({"population_type": "biophysical"})
+            expected = CircuitNodeIds.from_arrays(4 * ["default2"], [0, 1, 2, 3])
+            assert tested == expected
+
+            tested = circuit.nodes.ids(
+                {"population_type": ["virtual", "biophysical"], "node_id": [0]}
+            )
+            expected = CircuitNodeIds.from_tuples([("default", 0), ("default2", 0)])
+            assert tested == expected
+
+            tested = circuit.nodes.ids({"population_type": "fake"})
+            expected = CircuitNodeIds.from_arrays([], [])
+            assert tested == expected
+
     def test_get(self):
         # return all properties for all the ids
         tested = self.test_obj.get()
@@ -373,6 +398,50 @@ class TestNodes:
 
         with pytest.raises(BluepySnapError, match="Unknown properties required: {'unknown'}"):
             next(self.test_obj.get(properties="unknown"))
+
+        # Test querying with the population type
+        with copy_test_data() as (_, config_path):
+            with edit_config(config_path) as config:
+                config["networks"]["nodes"][0]["populations"]["default"]["type"] = "virtual"
+
+            circuit = Circuit(config_path)
+
+            tested = circuit.nodes.get(group={"population_type": "virtual"}, properties=["layer"])
+            tested = pd.concat(df for _, df in tested)
+            expected = pd.DataFrame(
+                {"layer": np.array([2, 6, 6], dtype=int)},
+                index=pd.MultiIndex.from_tuples(
+                    [
+                        ("default", 0),
+                        ("default", 1),
+                        ("default", 2),
+                    ],
+                    names=["population", "node_ids"],
+                ),
+            )
+            pdt.assert_frame_equal(tested, expected)
+
+            tested = circuit.nodes.get(
+                group={"population_type": "biophysical"}, properties=["layer"]
+            )
+            tested = pd.concat(df for _, df in tested)
+            expected = pd.DataFrame(
+                {"layer": np.array([7, 8, 8, 2], dtype=int)},
+                index=pd.MultiIndex.from_tuples(
+                    [
+                        ("default2", 0),
+                        ("default2", 1),
+                        ("default2", 2),
+                        ("default2", 3),
+                    ],
+                    names=["population", "node_ids"],
+                ),
+            )
+            pdt.assert_frame_equal(tested, expected)
+
+            tested = circuit.nodes.get(group={"population_type": "fake"}, properties=["layer"])
+            tested = dict(tested)
+            assert tested == {}
 
     def test_functionality_with_separate_node_set(self):
         with pytest.raises(BluepySnapError, match="Undefined node set"):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -139,7 +139,7 @@ def test_resolve_ids():
         {"eight", "nine"},
     ]
     for it in iterables:
-        assert expected == resolve_ids(data, "", {"str": it}).tolist()
+        assert expected == resolve_ids(data, "", "", {"str": it}).tolist()
 
     with pytest.raises(BluepySnapError) as e:
         resolve_ids(data, "", "", {"str": {"$regex": "*.some", "edge_id": 2}})

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -28,21 +28,25 @@ def test_positional_mask():
 
 def test_population_mask():
     data = pd.DataFrame(range(3))
-    queries, mask = _circuit_mask(data, "default", {"population": "default", "other": "val"})
+    queries, mask = _circuit_mask(
+        data, "default", "biophysical", {"population": "default", "other": "val"}
+    )
     assert queries == {"other": "val"}
     npt.assert_array_equal(mask, [True, True, True])
 
-    queries, mask = _circuit_mask(data, "default", {"population": "unknown", "other": "val"})
+    queries, mask = _circuit_mask(
+        data, "default", "biophysical", {"population": "unknown", "other": "val"}
+    )
     assert queries == {"other": "val"}
     npt.assert_array_equal(mask, [False, False, False])
 
     queries, mask = _circuit_mask(
-        data, "default", {"population": "default", "node_id": [2], "other": "val"}
+        data, "default", "biophysical", {"population": "default", "node_id": [2], "other": "val"}
     )
     assert queries == {"other": "val"}
     npt.assert_array_equal(mask, [False, False, True])
 
-    queries, mask = _circuit_mask(data, "default", {"other": "val"})
+    queries, mask = _circuit_mask(data, "default", "biophysical", {"other": "val"})
     assert queries == {"other": "val"}
     npt.assert_array_equal(mask, [True, True, True])
 
@@ -105,28 +109,28 @@ def test_resolve_ids():
     data = pd.DataFrame(
         [[1, 0.4, "seven"], [2, 0.5, "eight"], [3, 0.6, "nine"]], columns=["int", "float", "str"]
     )
-    assert [False, True, False] == resolve_ids(data, "", {"str": "eight"}).tolist()
-    assert [False, False, False] == resolve_ids(data, "", {"int": 1, "str": "eight"}).tolist()
+    assert [False, True, False] == resolve_ids(data, "", "", {"str": "eight"}).tolist()
+    assert [False, False, False] == resolve_ids(data, "", "", {"int": 1, "str": "eight"}).tolist()
     assert [True, True, False] == resolve_ids(
-        data, "", {"$or": [{"str": "seven"}, {"float": (0.5, 0.5)}]}
+        data, "", "", {"$or": [{"str": "seven"}, {"float": (0.5, 0.5)}]}
     ).tolist()
     assert [False, False, True] == resolve_ids(
-        data, "", {"$and": [{"str": "nine"}, {"int": 3}]}
+        data, "", "", {"$and": [{"str": "nine"}, {"int": 3}]}
     ).tolist()
     assert [False, False, True] == resolve_ids(
-        data, "", {"$and": [{"str": "nine"}, {"$or": [{"int": 1}, {"int": 3}]}]}
+        data, "", "", {"$and": [{"str": "nine"}, {"$or": [{"int": 1}, {"int": 3}]}]}
     ).tolist()
     assert [False, True, True] == resolve_ids(
-        data, "", {"$or": [{"float": (0.59, 0.61)}, {"$and": [{"str": "eight"}, {"int": 2}]}]}
+        data, "", "", {"$or": [{"float": (0.59, 0.61)}, {"$and": [{"str": "eight"}, {"int": 2}]}]}
     ).tolist()
     assert [True, False, True] == resolve_ids(
-        data, "", {"$or": [{"node_id": 0}, {"edge_id": 2}]}
+        data, "", "", {"$or": [{"node_id": 0}, {"edge_id": 2}]}
     ).tolist()
-    assert [False, False, False] == resolve_ids(data, "", {"$or": []}).tolist()
-    assert [True, True, True] == resolve_ids(data, "", {"$and": []}).tolist()
+    assert [False, False, False] == resolve_ids(data, "", "", {"$or": []}).tolist()
+    assert [True, True, True] == resolve_ids(data, "", "", {"$and": []}).tolist()
 
     with pytest.raises(BluepySnapError) as e:
-        resolve_ids(data, "", {"str": {"$regex": "*.some", "edge_id": 2}})
+        resolve_ids(data, "", "", {"str": {"$regex": "*.some", "edge_id": 2}})
     assert "Value operators can't be used with plain values" in e.value.args[0]
 
 


### PR DESCRIPTION
Added a query key `population_type` to query edge / node ids based on population type.

Examples:
```python
# Nodes
circuit.nodes.ids({"population_type": "biophysical"})
circuit.nodes.get({"population_type": ["astrocyte", "biophysical"]}, properties=["x", "y", "z"])

# Edges
circuit.nodes.ids({"population_type": "electrical"})
# NOTE: circuit.edges.get can't be queried the same way as circuit.nodes.get
```

Closes #228 