### PR TITLE
Reinforce `py311` in read the docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.11"
 
 python:
   install:


### PR DESCRIPTION
* docs build fail due to morphio not having wheels for py312