### PR TITLE
Simulation validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Version v2.1.0
+--------------
+
+New Features
+~~~~~~~~~~~~
+- Added simulation config validation
+- Added a new  commandline subcommand: ``validate-simulation``
+
+
 Version v2.0.2
 --------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,14 @@ New Features
 ~~~~~~~~~~~~
 - Added simulation config validation
 - Added a new  commandline subcommand: ``validate-simulation``
+- Added an alias ``validate-circuit`` for the old ``validate`` subcommand
+
+  - deprecated ``validate``
+
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+- Deprecated the commandline subcommand ``validate`` in favor of new ``validate-circuit`` command
 
 
 Version v2.0.2

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ This functionality is provided by either the cli function:
 
 .. code-block:: shell
 
-    bluepysnap validate my/circuit/path/circuit_config.json
+    bluepysnap validate-circuit my/circuit/path/circuit_config.json
 
 
 Or a python free function:

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,31 @@ Or a python free function:
     errors = validate("my/circuit/path/circuit_config.json")
 
 
+Simulation Validation
+~~~~~~~~~~~~~~~~~~~~~
+
+Similarly to circuit validation, Blue Brain SNAP also provides a SONATA simulation validator for verifying simulation configs.
+
+Currently, the validator only verifies that:
+
+- all the mandatory fields are present in the config file
+- all the properties in the `simulation config specification <https://sonata-extension.readthedocs.io/en/latest/sonata_simulation.html>`__ have correct data types and accepted values
+
+This functionality is provided by either the cli function:
+
+.. code-block:: shell
+
+    bluepysnap validate-simulation my/circuit/path/simulation_config.json
+
+
+Or a python free function:
+
+.. code-block:: python3
+
+    from bluepysnap.simulation_validation import validate
+    errors = validate("my/circuit/path/simulation_config.json")
+
+
 Acknowledgements
 ----------------
 

--- a/bluepysnap/circuit_validation.py
+++ b/bluepysnap/circuit_validation.py
@@ -5,7 +5,6 @@ The idea here is to not depend on libsonata if possible, so we can use this in a
 import logging
 from pathlib import Path
 
-import click
 import h5py
 import numpy as np
 import pandas as pd

--- a/bluepysnap/circuit_validation.py
+++ b/bluepysnap/circuit_validation.py
@@ -15,7 +15,7 @@ from bluepysnap.config import Parser
 from bluepysnap.exceptions import BluepySnapValidationError
 from bluepysnap.morph import EXTENSIONS_MAPPING
 from bluepysnap.sonata_constants import DEFAULT_EDGE_TYPE, DEFAULT_NODE_TYPE
-from bluepysnap.utils import load_json
+from bluepysnap.utils import load_json, print_validation_errors
 
 L = logging.getLogger("brainbuilder")
 MAX_MISSING_FILES_DISPLAY = 10
@@ -71,21 +71,6 @@ def _check_files(name, files):
         ]
 
     return []
-
-
-def _print_errors(errors):
-    """Some fancy errors printing."""
-    colors = {
-        BluepySnapValidationError.WARNING: "yellow",
-        BluepySnapValidationError.FATAL: "red",
-        BluepySnapValidationError.INFO: "green",
-    }
-
-    if not errors:
-        print(click.style("No Error: Success.", fg=colors[BluepySnapValidationError.INFO]))
-
-    for error in errors:
-        print(click.style(error.level + ": ", fg=colors[error.level]) + str(error))
 
 
 def _check_duplicate_populations(networks, key):
@@ -599,7 +584,7 @@ def validate(config_file, skip_slow, only_errors=False, print_errors=True):
         print_errors (bool): print errors
 
     Returns:
-        list: List of errors, empty if no errors
+        set: set of errors, empty if no errors
     """
     config = Parser.parse(load_json(config_file), str(Path(config_file).parent))
     errors = schemas.validate_circuit_schema(config_file, config)
@@ -618,6 +603,6 @@ def validate(config_file, skip_slow, only_errors=False, print_errors=True):
         errors = [e for e in errors if e.level == BluepySnapValidationError.FATAL]
 
     if print_errors:
-        _print_errors(errors)
+        print_validation_errors(errors)
 
     return set(errors)

--- a/bluepysnap/cli.py
+++ b/bluepysnap/cli.py
@@ -3,7 +3,9 @@ import logging
 
 import click
 
-from bluepysnap import circuit_validation
+from bluepysnap import circuit_validation, simulation_validation
+
+CLICK_EXISTING_FILE = click.Path(exists=True, file_okay=True, dir_okay=False)
 
 
 @click.group()
@@ -19,7 +21,7 @@ def cli(verbose):
 
 
 @cli.command()
-@click.argument("config_file", type=click.Path(exists=True, file_okay=True, dir_okay=False))
+@click.argument("config_file", type=CLICK_EXISTING_FILE)
 @click.option(
     "--skip-slow/--no-skip-slow",
     default=True,
@@ -30,7 +32,7 @@ def cli(verbose):
 )
 @click.option("--only-errors", is_flag=True, help="Only print fatal errors (ignore warnings)")
 def validate(config_file, skip_slow, only_errors):
-    """Validate of Sonata circuit based on config file.
+    """Validate Sonata circuit based on config file.
 
     Args:
         config_file (str): path to Sonata circuit config file
@@ -38,3 +40,14 @@ def validate(config_file, skip_slow, only_errors):
         only_errors (bool): only print fatal errors
     """
     circuit_validation.validate(config_file, skip_slow, only_errors)
+
+
+@cli.command()
+@click.argument("config_file", type=CLICK_EXISTING_FILE)
+def validate_simulation(config_file):
+    """Validate Sonata simulation based on config file.
+
+    Args:
+        config_file (str): path to Sonata simulation config file
+    """
+    simulation_validation.validate(config_file)

--- a/bluepysnap/schemas/__init__.py
+++ b/bluepysnap/schemas/__init__.py
@@ -3,4 +3,5 @@ from bluepysnap.schemas.schemas import (
     validate_circuit_schema,
     validate_edges_schema,
     validate_nodes_schema,
+    validate_simulation_schema,
 )

--- a/bluepysnap/schemas/definitions/simulation_input.yaml
+++ b/bluepysnap/schemas/definitions/simulation_input.yaml
@@ -1,0 +1,308 @@
+title: SONATA Simulation Input definitions
+description: schemas for different rules based on the input module
+$input_defs:
+  base:
+    type: object
+    required:
+      - module
+      - input_type
+      - delay
+      - duration
+      - node_set
+    properties:
+      module:
+        type: string
+        enum:
+          - "linear"
+          - "relative_linear"
+          - "pulse"
+          - "subthreshold"
+          - "hyperpolarizing"
+          - "synapse_replay"
+          - "seclamp"
+          - "noise"
+          - "shot_noise"
+          - "relative_shot_noise"
+          - "absolute_shot_noise"
+          - "ornstein_uhlenbeck"
+          - "relative_ornstein_uhlenbeck"
+      input_type:
+        type: string
+        enum:
+          - "spikes"
+          - "extracellular_stimulation"
+          - "current_clamp"
+          - "voltage_clamp"
+          - "conductance"
+      delay:
+        type: number
+      duration:
+        type: number
+      node_set:
+        type: string
+      amp_cv:
+        type: number
+      amp_end:
+        type: number
+      amp_mean:
+        type: number
+      amp_start:
+        type: number
+      amp_var:
+        type: number
+      decay_time:
+        type: number
+      dt:
+        $ref: "#/$simulation_defs/positive_float"
+      frequency:
+        type: number
+      mean:
+        type: number
+      mean_percent:
+        type: number
+      percent_end:
+        type: number
+      percent_less:
+        type: integer
+      percent_start:
+        type: number
+      random_seed:
+        $ref: "#/$simulation_defs/non_negative_integer"
+      rate:
+        type: number
+      reversal:
+        type: number
+      rise_time:
+        type: number
+      sd_percent:
+        type: number
+      series_resistance:
+        type: number
+      sigma:
+        type: number
+      spike_file:
+        type: string
+      source:
+        type: string
+      tau:
+        type: number
+      variance:
+        type: number
+      voltage:
+        type: number
+      width:
+        type: number
+  modules:
+    linear:
+      $ref: "#/$input_defs/base"
+      if:
+        properties:
+          module:
+            const: "linear"
+        required:
+          - module
+      then:
+        properties:
+          input_type:
+            const: "current_clamp"
+        required:
+          - amp_start
+    relative_linear:
+      $ref: "#/$input_defs/base"
+      if:
+        properties:
+          module:
+            const: "relative_linear"
+        required:
+          - module
+      then:
+        properties:
+          input_type:
+            const: "current_clamp"
+        required:
+          - percent_start
+    pulse:
+      $ref: "#/$input_defs/base"
+      if:
+        properties:
+          module:
+            const: "pulse"
+        required:
+          - module
+      then:
+        properties:
+          input_type:
+            const: "current_clamp"
+        required:
+          - amp_start
+          - width
+          - frequency
+    subthreshold:
+      $ref: "#/$input_defs/base"
+      if:
+        properties:
+          module:
+            const: "subthreshold"
+        required:
+          - module
+      then:
+        properties:
+          input_type:
+            const: "current_clamp"
+        required:
+          - percent_less
+    hyperpolarizing:
+      $ref: "#/$input_defs/base"
+      if:
+        properties:
+          module:
+            const: "hyperpolarizing"
+        required:
+          - module
+      then:
+        properties:
+          input_type:
+            const: "current_clamp"
+    synapse_replay:
+      $ref: "#/$input_defs/base"
+      if:
+        properties:
+          module:
+            const: "synapse_replay"
+        required:
+          - module
+      then:
+        properties:
+          input_type:
+            const: "spikes"
+        required:
+          - spike_file
+    seclamp:
+      $ref: "#/$input_defs/base"
+      if:
+        properties:
+          module:
+            const: "seclamp"
+        required:
+          - module
+      then:
+        properties:
+          input_type:
+            const: "voltage_clamp"
+        required:
+          - voltage
+    noise:
+      $ref: "#/$input_defs/base"
+      if:
+        properties:
+          module:
+            const: "noise"
+        required:
+          - module
+      then:
+        properties:
+          input_type:
+            const: "current_clamp"
+        oneOf:
+          - required: [mean]
+          - required: [mean_percent]
+        messages:
+          oneOf: "either 'mean' or 'mean_percent' is required (not both)"
+    shot_noise:
+      $ref: "#/$input_defs/base"
+      if:
+        properties:
+          module:
+            const: "shot_noise"
+        required:
+          - module
+      then:
+        properties:
+          input_type:
+            enum:
+             - "current_clamp"
+             - "conductance"
+        required:
+          - rise_time
+          - decay_time
+          - rate
+          - amp_mean
+          - amp_var
+    absolute_shot_noise:
+      $ref: "#/$input_defs/base"
+      if:
+        properties:
+          module:
+            const: "absolute_shot_noise"
+        required:
+          - module
+      then:
+        properties:
+          input_type:
+            enum:
+             - "current_clamp"
+             - "conductance"
+        required:
+          - rise_time
+          - decay_time
+          - rate
+          - amp_cv
+          - mean
+          - sigma
+    relative_shot_noise:
+      $ref: "#/$input_defs/base"
+      if:
+        properties:
+          module:
+            const: "relative_shot_noise"
+        required:
+          - module
+      then:
+        properties:
+          input_type:
+            enum:
+             - "current_clamp"
+             - "conductance"
+        required:
+          - rise_time
+          - decay_time
+          - rate
+          - amp_cv
+          - mean_percent
+          - sd_percent
+    ornstein_uhlenbeck:
+      $ref: "#/$input_defs/base"
+      if:
+        properties:
+          module:
+            const: "ornstein_uhlenbeck"
+        required:
+          - module
+      then:
+        properties:
+          input_type:
+            enum:
+             - "current_clamp"
+             - "conductance"
+        required:
+          - tau
+          - mean
+          - sigma
+    relative_ornstein_uhlenbeck:
+      $ref: "#/$input_defs/base"
+      if:
+        properties:
+          module:
+            const: "relative_ornstein_uhlenbeck"
+        required:
+          - module
+      then:
+        properties:
+          input_type:
+            enum:
+             - "current_clamp"
+             - "conductance"
+        required:
+          - tau
+          - mean_percent
+          - sd_percent

--- a/bluepysnap/schemas/simulation.yaml
+++ b/bluepysnap/schemas/simulation.yaml
@@ -11,6 +11,9 @@ properties:
     type: string
   target_simulator:
     type: string
+    enum:
+      - "CORENEURON"
+      - "NEURON"
   node_sets_file:
     type: string
   node_set:

--- a/bluepysnap/schemas/simulation.yaml
+++ b/bluepysnap/schemas/simulation.yaml
@@ -1,0 +1,229 @@
+title: SONATA Simulation Config
+description: schema for BBP SONATA simulation config
+required:
+  - run
+properties:
+  version:
+    type: number
+  manifest:
+    type: object
+  network:
+    type: string
+  target_simulator:
+    type: string
+  node_sets_file:
+    type: string
+  node_set:
+    type: string
+  run:
+    type: object
+    required:
+      - tstop
+      - dt
+      - random_seed
+    properties:
+      tstop:
+        type: number
+      dt:
+        $ref: "#/$simulation_defs/positive_float"
+      random_seed:
+        $ref: "#/$simulation_defs/non_negative_integer"
+      spike_threshold:
+        type: integer
+      integration_method:
+        type: string
+        enum:
+          - "0"
+          - "1"
+          - "2"
+      stimulus_seed:
+        $ref: "#/$simulation_defs/non_negative_integer"
+      ionchannel_seed:
+        $ref: "#/$simulation_defs/non_negative_integer"
+      minis_seed:
+        $ref: "#/$simulation_defs/non_negative_integer"
+      synapse_seed:
+        $ref: "#/$simulation_defs/non_negative_integer"
+      electrodes_file:
+        type: string
+  output:
+    type: object
+    properties:
+      output_dir:
+        type: string
+      log_file:
+        type: string
+      spikes_file:
+        type: string
+      spikes_sort_order:
+        type: string
+        enum:
+          - "by_id"
+          - "by_time"
+          - "none"
+  conditions:
+    type: object
+    properties:
+      celsius:
+        type: number
+      v_init:
+        type: number
+      spike_location:
+        type: string
+        enum:
+          - "AIS"
+          - "soma"
+      extracellular_calcium:
+        type: number
+      randomize_gaba_rise_time:
+        type: boolean
+      mechanisms:
+        type: object
+        patternProperties:
+          # "" is used as a wild card for suffix names of mod files
+          "":
+            type: object
+      modifications:
+        type: object
+        patternProperties:
+          # "" is used as a wild card for modification names
+          "":
+            type: object
+            required:
+              - node_set
+              - type
+            properties:
+              node_set:
+                type: string
+              type:
+                type: string
+                enum:
+                  - "ConfigureAllSections"
+                  - "TTX"
+              section_configure:
+                type: string
+            # if type == "ConfigureAllSections", section_configure is mandatory
+            if:
+              properties:
+                type:
+                  const: "ConfigureAllSections"
+              # if type is not required here, too, we get an error that 'section_configure' is required if type is not specified
+              required:
+                - type
+            then:
+              required:
+                - section_configure
+  inputs:
+    type: object
+    patternProperties:
+      # "" is used as a wild card for input name
+      "":
+        allOf:
+          - $ref: "#/$input_defs/modules/linear"
+          - $ref: "#/$input_defs/modules/relative_linear"
+          - $ref: "#/$input_defs/modules/pulse"
+          - $ref: "#/$input_defs/modules/subthreshold"
+          - $ref: "#/$input_defs/modules/hyperpolarizing"
+          - $ref: "#/$input_defs/modules/synapse_replay"
+          - $ref: "#/$input_defs/modules/seclamp"
+          - $ref: "#/$input_defs/modules/noise"
+          - $ref: "#/$input_defs/modules/shot_noise"
+          - $ref: "#/$input_defs/modules/absolute_shot_noise"
+          - $ref: "#/$input_defs/modules/relative_shot_noise"
+          - $ref: "#/$input_defs/modules/ornstein_uhlenbeck"
+          - $ref: "#/$input_defs/modules/relative_ornstein_uhlenbeck"
+  reports:
+    type: object
+    patternProperties:
+      # "" is used as a wild card for report name
+      "":
+        required:
+          - type
+          - variable_name
+          - dt
+          - start_time
+          - end_time
+        properties:
+          cells:
+            type: string
+          sections:
+            type: string
+            enum:
+              - "all"
+              - "apic"
+              - "axon"
+              - "dend"
+              - "soma"
+          type:
+            type: string
+            enum:
+              - "compartment"
+              - "lfp"
+              - "summation"
+              - "synapse"
+          scaling:
+            type: string
+            enum:
+              - "area"
+              - "none"
+          compartments:
+            type: string
+            enum:
+              - "all"
+              - "center"
+          variable_name:
+            type: string
+          unit:
+            type: string
+          dt:
+            $ref: "#/$simulation_defs/positive_float"
+          start_time:
+            type: number
+          end_time:
+            type: number
+          file_name:
+            type: string
+          enabled:
+            type: boolean
+  connection_overrides:
+    type: array
+    items:
+      type: object
+      required:
+        - name
+        - source
+        - target
+      properties:
+        name:
+          type: string
+        source:
+          type: string
+        target:
+          type: string
+        weight:
+          type: number
+        spont_minis:
+          type: number
+        synapse_configure:
+          type: string
+        modoverride:
+          type: string
+        synapse_delay_override:
+          type: number
+        delay:
+          type: number
+        neuromodulation_dtc:
+          type: number
+        neuromodulation_strength:
+          type: number
+  metadata:
+    type: object
+  beta_features:
+    type: object
+$simulation_defs:
+  non_negative_integer:
+    type: integer
+    minimum: 0
+  positive_float:
+    type: number
+    exclusiveMinimum: 0

--- a/bluepysnap/simulation_validation.py
+++ b/bluepysnap/simulation_validation.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from bluepysnap import schemas
+from bluepysnap.config import Parser
+from bluepysnap.utils import load_json, print_validation_errors
+
+
+def validate(config_file, print_errors=True):
+    """Validates Sonata simulation config.
+
+    Args:
+        config_file (str): path to Sonata simulation config file
+        print_errors (bool): print errors
+
+    Returns:
+        set: set of errors, empty if no errors
+    """
+    config = Parser.parse(load_json(config_file), str(Path(config_file).parent))
+    errors = schemas.validate_simulation_schema(config_file, config)
+
+    if print_errors:
+        print_validation_errors(errors)
+
+    return set(errors)

--- a/bluepysnap/simulation_validation.py
+++ b/bluepysnap/simulation_validation.py
@@ -1,3 +1,4 @@
+"""Standalone module that validates Sonata simulation. See ``validate-simulation`` function."""
 from pathlib import Path
 
 from bluepysnap import schemas

--- a/bluepysnap/utils.py
+++ b/bluepysnap/utils.py
@@ -21,6 +21,7 @@ import json
 import warnings
 from collections.abc import Iterable
 
+import click
 import numpy as np
 
 from bluepysnap.circuit_ids_types import IDS_DTYPE, CircuitEdgeId, CircuitNodeId
@@ -28,6 +29,7 @@ from bluepysnap.exceptions import (
     BluepySnapDeprecationError,
     BluepySnapDeprecationWarning,
     BluepySnapError,
+    BluepySnapValidationError,
 )
 from bluepysnap.sonata_constants import DYNAMICS_PREFIX
 
@@ -167,3 +169,18 @@ def quaternion2mat(aqw, aqx, aqy, aqz):
     )
 
     return [mm[..., i] for i in range(len(aq))]
+
+
+def print_validation_errors(errors):
+    """Some fancy errors printing."""
+    colors = {
+        BluepySnapValidationError.WARNING: "yellow",
+        BluepySnapValidationError.FATAL: "red",
+        BluepySnapValidationError.INFO: "green",
+    }
+
+    if not errors:
+        print(click.style("No Error: Success.", fg=colors[BluepySnapValidationError.INFO]))
+
+    for error in errors:
+        print(click.style(error.level + ": ", fg=colors[error.level]) + str(error))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,3 +23,11 @@ def test_cli_no_config():
     result = runner.invoke(cli, ["validate"])
     assert result.exit_code == 2
     assert "Missing argument 'CONFIG_FILE'" in result.stdout
+
+
+def test_cli_validate_simulation_correct():
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["validate-simulation", str(TEST_DATA_DIR / "simulation_config.json")]
+    )
+    assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,12 @@
+import warnings
 from unittest.mock import Mock, patch
 
 import click
+import pytest
 from click.testing import CliRunner
 
 from bluepysnap.cli import cli
+from bluepysnap.exceptions import BluepySnapDeprecationWarning
 
 from utils import TEST_DATA_DIR
 
@@ -13,7 +16,13 @@ from utils import TEST_DATA_DIR
 @patch("bluepysnap.schemas.validate_circuit_schema", Mock(return_value=[]))
 def test_cli_correct():
     runner = CliRunner()
-    result = runner.invoke(cli, ["validate", str(TEST_DATA_DIR / "circuit_config.json")])
+
+    with pytest.warns(
+        BluepySnapDeprecationWarning,
+        match="Calling circuit validation with 'validate' is deprecated",
+    ):
+        result = runner.invoke(cli, ["validate", str(TEST_DATA_DIR / "circuit_config.json")])
+
     assert result.exit_code == 0
     assert click.style("No Error: Success.", fg="green") in result.stdout
 
@@ -25,9 +34,20 @@ def test_cli_no_config():
     assert "Missing argument 'CONFIG_FILE'" in result.stdout
 
 
+@patch("bluepysnap.schemas.validate_nodes_schema", Mock(return_value=[]))
+@patch("bluepysnap.schemas.validate_edges_schema", Mock(return_value=[]))
+@patch("bluepysnap.schemas.validate_circuit_schema", Mock(return_value=[]))
+def test_cli_validate_circuit_correct():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["validate-circuit", str(TEST_DATA_DIR / "circuit_config.json")])
+    assert result.exit_code == 0
+    assert click.style("No Error: Success.", fg="green") in result.stdout
+
+
 def test_cli_validate_simulation_correct():
     runner = CliRunner()
     result = runner.invoke(
         cli, ["validate-simulation", str(TEST_DATA_DIR / "simulation_config.json")]
     )
     assert result.exit_code == 0
+    assert click.style("No Error: Success.", fg="green") in result.stdout

--- a/tests/test_schema_validation_simulation.py
+++ b/tests/test_schema_validation_simulation.py
@@ -1,0 +1,389 @@
+from copy import deepcopy
+from unittest.mock import Mock, patch
+
+import pytest
+
+import bluepysnap.schemas.schemas as test_module
+
+CONFIG_FILE = "fake_simulation.json"
+SCHEMA = test_module._parse_schema("simulation")
+
+MINIMUM_MANDATORY = {"run": {"tstop": 0.1, "dt": 0.1, "random_seed": 1}}
+
+MANDATORY_FOR_OPTIONALS = {
+    **MINIMUM_MANDATORY,
+    "conditions": {
+        "modifications": {
+            "TTX": {"node_set": "fake", "type": "TTX"},
+            "ConfigureAllSections": {
+                "node_set": "fake",
+                "type": "ConfigureAllSections",
+                "section_configure": "fake",
+            },
+        }
+    },
+    "reports": {
+        "fake": {
+            "type": "compartment",
+            "variable_name": "fake",
+            "dt": 0.1,
+            "start_time": 0.1,
+            "end_time": 0.1,
+        }
+    },
+    "connection_overrides": [
+        {
+            "name": "fake",
+            "source": "fake",
+            "target": "fake",
+        }
+    ],
+}
+
+
+def _get_fake_inputs(data):
+    """Creates an `inputs` entry with provided data and a few required properties"""
+    return {
+        "inputs": {
+            "fake_input": {"delay": 0.1, "duration": 0.1, "node_set": "fake_node_set", **data}
+        }
+    }
+
+
+def _get_remove_paths(config):
+    """Helper function to get paths to the leaf items in a nested dictionary."""
+    paths = []
+
+    def _recurse_paths(config, path=None):
+        path = path or []
+        for key, value in config.items():
+            if isinstance(value, dict):
+                _recurse_paths(config[key], path + [key])
+            elif isinstance(value, list):
+                _recurse_paths(config[key][0], path + [key, 0])
+            else:
+                paths.append(path + [key])
+
+    _recurse_paths(config)
+    return paths
+
+
+@patch.object(test_module, "_parse_schema", new=Mock(return_value=SCHEMA))
+def _validate(config):
+    """
+    Helper function to validate the schema.
+
+    Schema mocked to not have to parse it from file for every validation.
+    """
+    return test_module.validate_circuit_schema(CONFIG_FILE, config)
+
+
+def _remove_from_config(config, to_remove):
+    """Helper function to remove a value from a dictionary."""
+    for key in to_remove[:-1]:
+        config = config[key]
+    del config[to_remove[-1]]
+
+
+@pytest.mark.parametrize("config", [MINIMUM_MANDATORY, MANDATORY_FOR_OPTIONALS])
+def test_all_mandatory_fields_pass(config):
+    """Check that the defined mandatories pass"""
+    assert _validate(config) == []
+
+
+@pytest.mark.parametrize("to_remove", [["run"], *_get_remove_paths(MANDATORY_FOR_OPTIONALS)])
+def test_all_mandatory_fields_missing(to_remove):
+    """
+    Test that error is reported for all mandatory fields.
+
+    Inputs' mandatory fields are tested separately.
+    """
+    config = deepcopy(MANDATORY_FOR_OPTIONALS)
+    _remove_from_config(config, to_remove)
+
+    expected = f"{to_remove[-1]}' is a required property"
+    res = _validate(config)
+    assert len(res) == 1
+    assert expected in res[0].message
+
+
+@pytest.mark.parametrize(
+    "input_data",
+    [
+        {"module": "linear", "input_type": "current_clamp", "amp_start": 0.1},
+        {"module": "relative_linear", "input_type": "current_clamp", "percent_start": 0.1},
+        {
+            "module": "pulse",
+            "input_type": "current_clamp",
+            "amp_start": 0.1,
+            "width": 0.1,
+            "frequency": 0.1,
+        },
+        {"module": "subthreshold", "input_type": "current_clamp", "percent_less": 1},
+        {"module": "synapse_replay", "input_type": "spikes", "spike_file": "fake"},
+        {"module": "seclamp", "input_type": "voltage_clamp", "voltage": 0.1},
+        {"module": "noise", "input_type": "current_clamp", "mean": 0.1},
+        {"module": "noise", "input_type": "current_clamp", "mean_percent": 0.1},
+        {
+            "module": "shot_noise",
+            "input_type": "current_clamp",
+            "rise_time": 0.1,
+            "decay_time": 0.1,
+            "rate": 0.1,
+            "amp_mean": 0.1,
+            "amp_var": 0.1,
+        },
+        {
+            "module": "shot_noise",
+            "input_type": "conductance",
+            "rise_time": 0.1,
+            "decay_time": 0.1,
+            "rate": 0.1,
+            "amp_mean": 0.1,
+            "amp_var": 0.1,
+        },
+        {
+            "module": "absolute_shot_noise",
+            "input_type": "current_clamp",
+            "rise_time": 0.1,
+            "decay_time": 0.1,
+            "rate": 0.1,
+            "amp_cv": 0.1,
+            "mean": 0.1,
+            "sigma": 0.1,
+        },
+        {
+            "module": "absolute_shot_noise",
+            "input_type": "conductance",
+            "rise_time": 0.1,
+            "decay_time": 0.1,
+            "rate": 0.1,
+            "amp_cv": 0.1,
+            "mean": 0.1,
+            "sigma": 0.1,
+        },
+        {
+            "module": "relative_shot_noise",
+            "input_type": "current_clamp",
+            "rise_time": 0.1,
+            "decay_time": 0.1,
+            "rate": 0.1,
+            "amp_cv": 0.1,
+            "mean_percent": 0.1,
+            "sd_percent": 0.1,
+        },
+        {
+            "module": "relative_shot_noise",
+            "input_type": "conductance",
+            "rise_time": 0.1,
+            "decay_time": 0.1,
+            "rate": 0.1,
+            "amp_cv": 0.1,
+            "mean_percent": 0.1,
+            "sd_percent": 0.1,
+        },
+        {
+            "module": "ornstein_uhlenbeck",
+            "input_type": "current_clamp",
+            "tau": 0.1,
+            "mean": 0.1,
+            "sigma": 0.1,
+        },
+        {
+            "module": "ornstein_uhlenbeck",
+            "input_type": "conductance",
+            "tau": 0.1,
+            "mean": 0.1,
+            "sigma": 0.1,
+        },
+        {
+            "module": "relative_ornstein_uhlenbeck",
+            "input_type": "current_clamp",
+            "tau": 0.1,
+            "mean_percent": 0.1,
+            "sd_percent": 0.1,
+        },
+        {
+            "module": "relative_ornstein_uhlenbeck",
+            "input_type": "conductance",
+            "tau": 0.1,
+            "mean_percent": 0.1,
+            "sd_percent": 0.1,
+        },
+    ],
+)
+def test_inputs_expected_values(input_data):
+    """Test that error is reported on missing mandatory fields and on wrong `input_type`."""
+    tested = _get_fake_inputs(input_data)
+    module, input_type = input_data["module"], input_data["input_type"]
+
+    config = {**MINIMUM_MANDATORY, **tested}
+    assert _validate(config) == []
+
+    for entry in _get_remove_paths(tested):
+        conf = deepcopy(config)
+        _remove_from_config(conf, entry)
+        res = _validate(conf)
+        assert len(res) == 1
+
+        removed = entry[-1]
+
+        # in the case of `noise` either `mean` or `mean_percent` is required. If neither is given
+        # message reports that the input definition is not valid under any of the schemas.
+        if module == "noise" and removed in ("mean", "mean_percent"):
+            assert "either 'mean' or 'mean_percent' is required (not both)" in res[0].message
+        else:
+            assert f"'{removed}' is a required property" in res[0].message
+
+    wrong_type = "extracellular_stimulation"
+    conf = {**MINIMUM_MANDATORY, **_get_fake_inputs({**input_data, "input_type": wrong_type})}
+    res = _validate(conf)
+    assert len(res) == 1
+
+    # if there's multiple possible input types for a module the message reports that
+    # [...].input_type: 'fake_type' is not valid under any of the given schemas
+    if "shot_noise" in module or "ornstein_uhlenbeck" in module:
+        assert (
+            f"input_type: '{wrong_type}' is not one of ['current_clamp', 'conductance']"
+            in res[0].message
+        )
+    else:
+        assert f"input_type: '{input_type}' was expected" in res[0].message
+
+
+def test_run():
+    config = deepcopy(MINIMUM_MANDATORY)
+    config["run"].update(
+        {
+            "spike_threshold": 1,
+            "integration_method": "0",
+            "stimulus_seed": 1,
+            "ionchannel_seed": 1,
+            "minis_seed": 1,
+            "synapse_seed": 1,
+            "electrodes_file": "fake_file",
+        }
+    )
+    assert _validate(config) == []
+
+    config["run"]["integration_method"] = "fail"
+
+    res = _validate(config)
+    assert "integration_method: 'fail' is not one of ['0', '1', '2']" in res[0].message
+
+
+def test_output():
+    config = {
+        **MINIMUM_MANDATORY,
+        "output": {
+            "output_dir": "fake",
+            "log_file": "fake",
+            "spikes_file": "fake",
+            "spikes_sort_order": "none",
+        },
+    }
+    assert _validate(config) == []
+
+    config["output"]["spikes_sort_order"] = "fail"
+    res = _validate(config)
+    assert len(res) == 1
+    assert "spikes_sort_order: 'fail' is not one of ['by_id', 'by_time', 'none']" in res[0].message
+
+
+def test_conditions():
+    config = {
+        **MINIMUM_MANDATORY,
+        "conditions": {
+            "celsius": 0.1,
+            "v_init": 0.1,
+            "spike_location": "soma",
+            "extracellular_calcium": 0.1,
+            "randomize_gaba_rise_time": True,
+            "mechanisms": {"fake_mechanism": {"fake_property": "fake"}},
+            "modifications": {
+                "fake_modification": {
+                    "node_set": "fake_node_set",
+                    "type": "TTX",
+                }
+            },
+        },
+    }
+    assert _validate(config) == []
+
+    config["conditions"]["spike_location"] = "fail_0"
+    config["conditions"]["modifications"]["fake_modification"]["type"] = "fail_1"
+
+    res = _validate(config)
+    assert len(res) == 1
+    assert "spike_location: 'fail_0' is not one of ['AIS', 'soma']" in res[0].message
+    assert "type: 'fail_1' is not one of ['ConfigureAllSections', 'TTX']" in res[0].message
+
+
+def test_reports():
+    config = deepcopy(MANDATORY_FOR_OPTIONALS)
+    config["reports"]["fake"].update(
+        {
+            "cells": "fake_node_set",
+            "sections": "soma",
+            "scaling": "none",
+            "compartments": "center",
+            "unit": "fake_unit",
+            "file_name": "fake_file",
+            "enabled": True,
+        }
+    )
+    assert _validate(config) == []
+
+    config["reports"]["fake"]["sections"] = "fail_0"
+    config["reports"]["fake"]["scaling"] = "fail_1"
+    config["reports"]["fake"]["compartments"] = "fail_2"
+
+    res = _validate(config)
+    assert len(res) == 1
+    assert (
+        "sections: 'fail_0' is not one of ['all', 'apic', 'axon', 'dend', 'soma']" in res[0].message
+    )
+    assert "scaling: 'fail_1' is not one of ['area', 'none']" in res[0].message
+    assert "compartments: 'fail_2' is not one of ['all', 'center']" in res[0].message
+
+
+def test_inputs():
+    input_properties = {
+        "module": "noise",
+        "input_type": "current_clamp",
+        "mean": 0.1,
+        "amp_cv": 0.1,
+        "amp_end": 0.1,
+        "amp_mean": 0.1,
+        "amp_start": 0.1,
+        "amp_var": 0.1,
+        "decay_time": 0.1,
+        "dt": 0.1,
+        "frequency": 0.1,
+        "percent_end": 0.1,
+        "percent_less": 1,
+        "percent_start": 0.1,
+        "random_seed": 1,
+        "rate": 0.1,
+        "reversal": 0.1,
+        "rise_time": 0.1,
+        "sd_percent": 0.1,
+        "series_resistance": 0.1,
+        "sigma": 0.1,
+        "spike_file": "fake_file",
+        "source": "fake_node_set",
+        "tau": 0.1,
+        "variance": 0.1,
+        "voltage": 0.1,
+        "width": 0.1,
+    }
+    input_conf = _get_fake_inputs(input_properties)
+    config = {**MINIMUM_MANDATORY, **input_conf}
+
+    assert _validate(config) == []
+
+    # `mean` and `mean_percent` can not both be defined
+    config["inputs"]["fake_input"]["mean_percent"] = 0.1
+    res = _validate(config)
+    assert len(res) == 1
+    assert "fake_input: either 'mean' or 'mean_percent' is required (not both)" in res[0].message

--- a/tests/test_schema_validation_simulation.py
+++ b/tests/test_schema_validation_simulation.py
@@ -387,3 +387,55 @@ def test_inputs():
     res = _validate(config)
     assert len(res) == 1
     assert "fake_input: either 'mean' or 'mean_percent' is required (not both)" in res[0].message
+
+
+def test_rest_of_config():
+    config = {
+        **MINIMUM_MANDATORY,
+        "version": 1.1,
+        "manifest": {"fake_path_key": "fake_path_value"},
+        "network": "fake_circuit_path",
+        "target_simulator": "NEURON",
+        "node_sets_file": "fake_node_sets_file",
+        "node_set": "fake_node_set",
+        "metadata": {
+            "fake_meta_key_0": "fake_string",
+            "fake_meta_key_1": -0.1,
+            "fake_meta_key_2": {},
+            "fake_meta_key_3": [],
+        },
+        "beta_features": {
+            "fake_beta_key_0": "fake_string",
+            "fake_beta_key_1": -0.1,
+            "fake_beta_key_2": {},
+            "fake_beta_key_3": [],
+        },
+    }
+
+    assert _validate(config) == []
+
+    config["target_simulator"] = "fail"
+
+    res = _validate(config)
+    assert "target_simulator: 'fail' is not one of ['CORENEURON', 'NEURON']" in res[0].message
+
+
+def test_type_definitions():
+    config = deepcopy(MINIMUM_MANDATORY)
+    config["run"].update(
+        {
+            "dt": 0,
+            "spike_threshold": 0.1,
+            "random_seed": -1,
+            "tstop": "1",
+            "electrodes_file": 1,
+        }
+    )
+
+    res = _validate(config)
+
+    assert "dt: 0 is less than or equal to the minimum of 0" in res[0].message
+    assert "spike_threshold: 0.1 is not of type 'integer'" in res[0].message
+    assert "random_seed: -1 is less than the minimum of 0" in res[0].message
+    assert "tstop: '1' is not of type 'number'" in res[0].message
+    assert "electrodes_file: 1 is not of type 'string'" in res[0].message

--- a/tests/test_schema_validation_simulation.py
+++ b/tests/test_schema_validation_simulation.py
@@ -87,7 +87,7 @@ def _remove_from_config(config, to_remove):
 
 @pytest.mark.parametrize("config", [MINIMUM_MANDATORY, MANDATORY_FOR_OPTIONALS])
 def test_all_mandatory_fields_pass(config):
-    """Check that the defined mandatories pass"""
+    """Check that the globally defined mandatory fields pass validation."""
     assert _validate(config) == []
 
 
@@ -228,8 +228,7 @@ def test_inputs_expected_values(input_data):
 
         removed = entry[-1]
 
-        # in the case of `noise` either `mean` or `mean_percent` is required. If neither is given
-        # message reports that the input definition is not valid under any of the schemas.
+        # noise module requires either mean or mean percent
         if module == "noise" and removed in ("mean", "mean_percent"):
             assert "either 'mean' or 'mean_percent' is required (not both)" in res[0].message
         else:
@@ -240,8 +239,7 @@ def test_inputs_expected_values(input_data):
     res = _validate(conf)
     assert len(res) == 1
 
-    # if there's multiple possible input types for a module the message reports that
-    # [...].input_type: 'fake_type' is not valid under any of the given schemas
+    # modules *shot_noise, *ornstein_uhlenbeck have two possible input types
     if "shot_noise" in module or "ornstein_uhlenbeck" in module:
         assert (
             f"input_type: '{wrong_type}' is not one of ['current_clamp', 'conductance']"

--- a/tests/test_simulation_validation.py
+++ b/tests/test_simulation_validation.py
@@ -1,0 +1,18 @@
+from unittest.mock import Mock, patch
+
+import bluepysnap.simulation_validation as test_module
+
+from utils import TEST_DATA_DIR
+
+
+@patch.object(test_module, "print_validation_errors")
+def test_validate(mock_print):
+    config = TEST_DATA_DIR / "simulation_config.json"
+
+    res = test_module.validate(config, print_errors=False)
+    mock_print.assert_not_called()
+    assert res == set()
+
+    res = test_module.validate(config, print_errors=True)
+    mock_print.assert_called_once_with([])
+    assert res == set()


### PR DESCRIPTION
Added schema based validation for simulation configurations.
* added schemas and tests for them
* added commandline subcommand `validate-simulation`
* deprecated `validate` in favor of `validate-circuit`
   * both can be used, former gives `BluepySnapDeprecationWarning`

It would also make sense to further the config values, such as 
* existence of node sets
* existence of files 
   * circuit config
   * node sets file
   * spike files
* etc

and possibly add the option to also run the circuit validation for the circuit used in the simulation (provided that `network` is defined).

But all of the other features should be added in a separate PR, this one is big enough as it is. 