### PR TITLE
Add some basic linting to tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,3 +91,13 @@ extension-pkg-whitelist = [
 ignored-modules = [
     'numpy',
 ]
+
+[tool.pylint.tests]
+disable = [
+    'all',
+]
+enable = [
+    'unused-import',
+    'unused-variable',
+    'unused-argument',
+]

--- a/tests/test__plotting.py
+++ b/tests/test__plotting.py
@@ -1,14 +1,11 @@
 import sys
 from unittest.mock import Mock, patch
 
-import numpy as np
-import pandas as pd
 import pytest
 
 import bluepysnap._plotting as test_module
 from bluepysnap.exceptions import BluepySnapError
 from bluepysnap.simulation import Simulation
-from bluepysnap.spike_report import FilteredSpikeReport, SpikeReport
 
 from utils import TEST_DATA_DIR
 

--- a/tests/test_circuit_validation.py
+++ b/tests/test_circuit_validation.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 import bluepysnap.circuit_validation as test_module
-from bluepysnap.exceptions import BluepySnapError, BluepySnapValidationError
+from bluepysnap.exceptions import BluepySnapValidationError
 
 from utils import TEST_DATA_DIR, copy_test_data, edit_config
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,9 @@
-import warnings
 from unittest.mock import Mock, patch
 
 import click
-import pytest
 from click.testing import CliRunner
 
 from bluepysnap.cli import cli
-from bluepysnap.exceptions import BluepySnapDeprecationWarning
 
 from utils import TEST_DATA_DIR
 

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -1,12 +1,10 @@
 import pickle
-from unittest.mock import PropertyMock, patch
 
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pandas.testing as pdt
 import pytest
-from numpy import dtype
 
 import bluepysnap.edges as test_module
 from bluepysnap.bbp import Synapse

--- a/tests/test_neuron_models.py
+++ b/tests/test_neuron_models.py
@@ -12,12 +12,12 @@ from bluepysnap.circuit_ids_types import CircuitNodeId
 from bluepysnap.exceptions import BluepySnapError
 from bluepysnap.sonata_constants import Node
 
-from utils import TEST_DATA_DIR, copy_config, copy_test_data, create_node_population, edit_config
+from utils import TEST_DATA_DIR, copy_test_data, create_node_population, edit_config
 
 
 def test_invalid_model_type():
     """test that model type, other than 'biophysical' throws an error"""
-    with copy_test_data() as (circuit_copy_path, config_copy_path):
+    with copy_test_data() as (_, config_copy_path):
         config = CircuitConfig.from_config(config_copy_path).to_dict()
         nodes_file = config["networks"]["nodes"][0]["nodes_file"]
         with h5py.File(nodes_file, "r+") as h5f:
@@ -35,7 +35,6 @@ def test_invalid_model_type():
 
 def test_get_invalid_node_id():
     nodes = create_node_population(str(TEST_DATA_DIR / "nodes.h5"), "default")
-    config = CircuitConfig.from_config(TEST_DATA_DIR / "circuit_config.json").to_dict()
     test_obj = test_module.NeuronModelsHelper(nodes._properties, nodes)
 
     with pytest.raises(BluepySnapError) as e:
@@ -45,7 +44,6 @@ def test_get_invalid_node_id():
 
 def test_get_filepath_biophysical():
     nodes = create_node_population(str(TEST_DATA_DIR / "nodes.h5"), "default")
-    config = CircuitConfig.from_config(TEST_DATA_DIR / "circuit_config.json").to_dict()
     test_obj = test_module.NeuronModelsHelper(nodes._properties, nodes)
 
     node_id = 0
@@ -91,7 +89,7 @@ def test_absolute_biophysical_dir():
 
 
 def test_no_biophysical_dir():
-    with copy_test_data() as (data_dir, circuit_config):
+    with copy_test_data() as (_, circuit_config):
         with edit_config(circuit_config) as config:
             del config["components"]["biophysical_neuron_models_dir"]
 

--- a/tests/test_node_population.py
+++ b/tests/test_node_population.py
@@ -4,7 +4,6 @@ import pickle
 import sys
 from unittest import mock
 
-import libsonata
 import numpy as np
 import numpy.testing as npt
 import pandas as pd

--- a/tests/test_node_sets.py
+++ b/tests/test_node_sets.py
@@ -1,6 +1,5 @@
 import json
 import re
-from unittest.mock import patch
 
 import libsonata
 import pytest

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,12 +1,10 @@
 import pickle
-from unittest.mock import PropertyMock, patch
 
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pandas.testing as pdt
 import pytest
-from numpy import dtype
 
 import bluepysnap.nodes as test_module
 from bluepysnap.circuit import Circuit

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,6 +1,4 @@
-import re
 from collections.abc import Iterable
-from pathlib import Path
 
 import h5py
 import numpy as np
@@ -248,7 +246,7 @@ def test_validate_edges_ok():
     ),
 )
 def test_validate_nodes_biophysical_missing_required(missing):
-    with copy_test_data() as (circuit_copy_path, config_copy_path):
+    with copy_test_data() as (circuit_copy_path, _):
         nodes_file = circuit_copy_path / "nodes_single_pop.h5"
         with h5py.File(nodes_file, "r+") as h5f:
             del h5f[missing]
@@ -299,7 +297,7 @@ def test_validate_nodes_biophysical_missing_required(missing):
     ),
 )
 def test_validate_edges_chemical_missing_required(missing):
-    with copy_test_data() as (circuit_copy_path, config_copy_path):
+    with copy_test_data() as (circuit_copy_path, _):
         edges_file = circuit_copy_path / "edges_single_pop.h5"
         with h5py.File(edges_file, "r+") as h5f:
             del h5f[missing]
@@ -394,7 +392,7 @@ def test_virtual_node_population_error():
 
 def test_validate_edges_missing_attributes_field():
     # has no attributes at all
-    with copy_test_data() as (circuit_copy_path, config_copy_path):
+    with copy_test_data() as (circuit_copy_path, _):
         edges_file = circuit_copy_path / "edges_single_pop.h5"
         with h5py.File(edges_file, "r+") as h5f:
             del h5f["edges/default/source_node_id"].attrs["node_population"]
@@ -405,7 +403,7 @@ def test_validate_edges_missing_attributes_field():
 
 def test_validate_edges_missing_attribute():
     # has attributes but not the required ones
-    with copy_test_data() as (circuit_copy_path, config_copy_path):
+    with copy_test_data() as (circuit_copy_path, _):
         edges_file = circuit_copy_path / "edges_single_pop.h5"
         with h5py.File(edges_file, "r+") as h5f:
             del h5f["edges/default/source_node_id"].attrs["node_population"]
@@ -425,7 +423,7 @@ def test_validate_edges_missing_attribute():
     ),
 )
 def test_wrong_datatype(field):
-    with copy_test_data() as (circuit_copy_path, config_copy_path):
+    with copy_test_data() as (circuit_copy_path, _):
         edges_file = circuit_copy_path / "edges_single_pop.h5"
         with h5py.File(edges_file, "r+") as h5f:
             del h5f[field]
@@ -444,7 +442,7 @@ def test__get_reference_resolver():
 
 
 def test_nodes_schema_types():
-    property_types, dynamics_params = test_module.nodes_schema_types("biophysical")
+    property_types, _ = test_module.nodes_schema_types("biophysical")
     assert "x" in property_types
     assert property_types["x"] == np.float32
 

--- a/tests/test_simulation_validation.py
+++ b/tests/test_simulation_validation.py
@@ -738,7 +738,6 @@ def test_validate_reports(tmp_path):
     fail_1_file = tmp_path / "non_existent.h5"
     fail_2_file = tmp_path / "fail_2.h5"
 
-    report = {"cells": "fake_node_set"}
     config = {
         "_node_sets_instance": node_sets,
         "_output_dir": tmp_path,

--- a/tests/test_spike_report.py
+++ b/tests/test_spike_report.py
@@ -269,14 +269,14 @@ class TestPopulationSpikeReport:
     @patch(
         test_module.__name__ + ".PopulationSpikeReport.resolve_nodes", return_value=np.asarray([4])
     )
-    def test_get_not_in_report(self, mock):
+    def test_get_not_in_report(self, _):
         pdt.assert_series_equal(self.test_obj.get(4), _create_series([], []))
 
     @patch(
         test_module.__name__ + ".PopulationSpikeReport.resolve_nodes",
         return_value=np.asarray([0, 4]),
     )
-    def test_get_not_in_report(self, mock):
+    def test_get_not_in_report(self, _):
         pdt.assert_series_equal(self.test_obj.get([0, 4]), _create_series([0, 0], [0.2, 1.3]))
 
     def test_node_ids(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,9 +8,7 @@ from contextlib import contextmanager
 from distutils.dir_util import copy_tree
 from pathlib import Path
 
-import libsonata
 import numpy.testing as npt
-import pytest
 
 from bluepysnap.circuit import Circuit
 from bluepysnap.nodes import NodePopulation, Nodes

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
     isort --check {[base]name} tests setup.py doc/source/conf.py
     pycodestyle {[base]name}
     pydocstyle {[base]name}
-    pylint -j4 {[base]name}
+    pylint -j4 {[base]name} tests
 
 [testenv:format]
 deps =


### PR DESCRIPTION
I noticed there was a bunch of unused imports and variables in tests:
* added some very basic linting to help keep them cleaner
* fixed lint issues