### PR TITLE
Made Edges/EdgePopulation get functions more consistent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Version v3.1.0
+--------------
+
+Improvements
+~~~~~~~~~~~~
+- Made ``Edges`` and ``EdgePopulation`` ``get`` functions more consistent
+
+  - Both now return ``self.ids(query)`` if ``properties=None``
+  - ``properties`` is now a keyword argument in ``EdgePopulation.get``
+
+
 Version v3.0.1
 --------------
 

--- a/bluepysnap/edges/edge_population.py
+++ b/bluepysnap/edges/edge_population.py
@@ -288,7 +288,7 @@ class EdgePopulation:
             result = result[:limit]
         return utils.ensure_ids(result)
 
-    def get(self, edge_ids, properties):
+    def get(self, edge_ids, properties=None):
         """Edge properties as pandas DataFrame.
 
         Args:

--- a/bluepysnap/edges/edges.py
+++ b/bluepysnap/edges/edges.py
@@ -100,7 +100,7 @@ class Edges(
         if edge_ids is None:
             raise BluepySnapError("You need to set edge_ids in get.")
         if properties is None:
-            return edge_ids
+            return self.ids(edge_ids)
         return super().get(edge_ids, properties)
 
     def afferent_nodes(self, target, unique=True):


### PR DESCRIPTION
### Old behavior
`Edges.get`: 
* return the query as is if `properties` is `None`
* `properties` is optional (defaults to `None`)

`EdgePopulation.get`: 
* return resolved ids if `properties` is `None` 
* require `properties` to be defined in the function call

### New behavior:
`Edges.get` / `EdgePopulation.get`: 
* return resolved ids if `properties` is `None` 
* `properties` is optional (defaults to `None`)