### PR TITLE
Create aliases for `{a,e}fferent_{edges,nodes}`

### DIFF
--- a/bluepysnap/edges/edge_population.py
+++ b/bluepysnap/edges/edge_population.py
@@ -627,6 +627,12 @@ class EdgePopulation:
             raise BluepySnapError(f"It appears {self.name} does not have synapse indices")
         return open_index(index_dir)
 
+    # ALIASES
+    edges_by_source = efferent_edges
+    edges_by_target = afferent_edges
+    target_nodes_by_source = efferent_nodes
+    source_nodes_by_target = afferent_nodes
+
     def __getstate__(self):
         """Make EdgePopulation pickle-able, without storing state of caches."""
         return self._circuit, self.name

--- a/bluepysnap/edges/edges.py
+++ b/bluepysnap/edges/edges.py
@@ -250,6 +250,12 @@ class Edges(
                 return_edge_count=return_edge_count,
             )
 
+    # ALIASES
+    edges_by_source = efferent_edges
+    edges_by_target = afferent_edges
+    target_nodes_by_source = efferent_nodes
+    source_nodes_by_target = afferent_nodes
+
     def __getstate__(self):
         """Make Edges pickle-able, without storing state of caches."""
         return self._circuit


### PR DESCRIPTION
Oftentimes, the naming of `afferent_edges`/`efferent_edges`/`afferent_nodes`/`efferent_nodes` cause confusion among our users. Also, quite frankly, I always have to look them up too as they don't feel intuitive.  It's not clear what they mean and when is it needed to query by source nodes and when by target nodes.

To remove the ambiguity without introducing breaking changes, I created aliases for them (naming is open for discussion):
```python
edges_by_source = efferent_edges
edges_by_target = afferent_edges
target_nodes_by_source = efferent_nodes
source_nodes_by_target = afferent_nodes
```