### PR TITLE
add option to ignore datatypes while validating

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Improvements
 - Added the possibility to query Edge IDs and Node IDs based on edge/node population type using query key ``population_type``
 
   - the types conform to `node types <https://sonata-extension.readthedocs.io/en/latest/sonata_config.html#populations>`_ and `edge types <https://sonata-extension.readthedocs.io/en/latest/sonata_config.html#id4>`_ defined in the sonata specification
+- teach the `bluepysnap validate-circuit` and `bluepysnap validate-simulation` the ability to `--ignore-datatype-errors` so that mismatches of datatypes to the specification are ignored
 
 
 Version v3.0.1

--- a/bluepysnap/circuit_validation.py
+++ b/bluepysnap/circuit_validation.py
@@ -481,7 +481,7 @@ def validate_edge_population(edges_file, name, nodes):
     return []
 
 
-def validate_edges_dict(edges_dict, nodes, skip_slow):
+def validate_edges_dict(edges_dict, nodes, skip_slow, ignore_datatype_errors):
     """Validate an item in the "edges" list.
 
     Args:
@@ -518,7 +518,9 @@ def validate_edges_dict(edges_dict, nodes, skip_slow):
             virtual = False
             if pop_type == "chemical":
                 virtual = _is_source_node_virtual(edges_dict, name, nodes)
-            errors += schemas.validate_edges_schema(edges_file, pop_type, virtual)
+            errors += schemas.validate_edges_schema(
+                edges_file, pop_type, virtual, ignore_datatype_errors
+            )
             if not skip_slow:
                 errors += validate_edge_population(edges_file, name, nodes)
         else:
@@ -527,7 +529,7 @@ def validate_edges_dict(edges_dict, nodes, skip_slow):
     return errors
 
 
-def validate_nodes_dict(nodes_dict, components):
+def validate_nodes_dict(nodes_dict, components, ignore_datatype_errors):
     """Validate an item in the "nodes" list.
 
     Args:
@@ -544,7 +546,9 @@ def validate_nodes_dict(nodes_dict, components):
         nodes_file = nodes_dict["nodes_file"]
 
         if Path(nodes_file).is_file():
-            errors = schemas.validate_nodes_schema(nodes_file, population["type"])
+            errors = schemas.validate_nodes_schema(
+                nodes_file, population["type"], ignore_datatype_errors
+            )
             errors += validate_node_population(nodes_file, population, pop_name)
         else:
             errors.append(BluepySnapValidationError.fatal(f'Invalid "nodes_file": {nodes_file}'))
@@ -552,7 +556,7 @@ def validate_nodes_dict(nodes_dict, components):
     return errors
 
 
-def validate_networks(config, skip_slow):
+def validate_networks(config, skip_slow, ignore_datatype_errors):
     """Validate "networks" part of the config.
 
     Acts as a starting point of validation.
@@ -566,15 +570,17 @@ def validate_networks(config, skip_slow):
 
     for nodes_dict in nodes:
         if "nodes_file" in nodes_dict:
-            errors += validate_nodes_dict(nodes_dict, components)
+            errors += validate_nodes_dict(nodes_dict, components, ignore_datatype_errors)
     for edges_dict in config["networks"].get("edges", []):
         if "edges_file" in edges_dict:
-            errors += validate_edges_dict(edges_dict, nodes, skip_slow)
+            errors += validate_edges_dict(edges_dict, nodes, skip_slow, ignore_datatype_errors)
 
     return errors
 
 
-def validate(config_file, skip_slow, only_errors=False, print_errors=True):
+def validate(
+    config_file, skip_slow, only_errors=False, print_errors=True, ignore_datatype_errors=False
+):
     """Validates Sonata circuit.
 
     Args:
@@ -587,10 +593,10 @@ def validate(config_file, skip_slow, only_errors=False, print_errors=True):
         set: set of errors, empty if no errors
     """
     config = Parser.parse(load_json(config_file), str(Path(config_file).parent))
-    errors = schemas.validate_circuit_schema(config_file, config)
+    errors = schemas.validate_circuit_schema(config_file, config, ignore_datatype_errors)
 
     if "networks" in config:
-        errors += validate_networks(config, skip_slow)
+        errors += validate_networks(config, skip_slow, ignore_datatype_errors)
 
     if _check_partial_circuit_config(config):
         message = (

--- a/bluepysnap/cli.py
+++ b/bluepysnap/cli.py
@@ -1,6 +1,5 @@
 """The project's command line launcher."""
 
-import functools
 import logging
 
 import click
@@ -22,45 +21,48 @@ def cli(verbose):
     )
 
 
-def circuit_validation_params(func):
-    """Small helper to have shared params."""
-
-    @click.argument("config_file", type=CLICK_EXISTING_FILE)
-    @click.option(
-        "--skip-slow/--no-skip-slow",
-        default=True,
-        help=(
-            "Skip slow checks; checking all edges refer to existing node ids, "
-            "edge indices are correct, etc"
-        ),
-    )
-    @click.option("--only-errors", is_flag=True, help="Only print fatal errors (ignore warnings)")
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
 @cli.command()
-@circuit_validation_params
-def validate_circuit(config_file, skip_slow, only_errors):
+@click.argument("config_file", type=CLICK_EXISTING_FILE)
+@click.option(
+    "--skip-slow/--no-skip-slow",
+    default=True,
+    help=(
+        "Skip slow checks; checking all edges refer to existing node ids, "
+        "edge indices are correct, etc"
+    ),
+)
+@click.option("--only-errors", is_flag=True, help="Only print fatal errors (ignore warnings)")
+@click.option(
+    "--ignore-datatype-errors",
+    is_flag=True,
+    help="Ignore errors related to mismatch of datatypes: ie: float64 used instead of float32",
+)
+def validate_circuit(config_file, skip_slow, only_errors, ignore_datatype_errors):
     """Validate Sonata circuit based on config file.
 
     Args:
         config_file (str): path to Sonata circuit config file
         skip_slow (bool): skip slow tests
         only_errors (bool): only print fatal errors
+        ignore_datatype_errors (bool): ignore checks related to datatypes
     """
-    circuit_validation.validate(config_file, skip_slow, only_errors)
+    circuit_validation.validate(
+        config_file, skip_slow, only_errors, ignore_datatype_errors=ignore_datatype_errors
+    )
 
 
 @cli.command()
 @click.argument("config_file", type=CLICK_EXISTING_FILE)
-def validate_simulation(config_file):
+@click.option(
+    "--ignore-datatype-errors",
+    is_flag=True,
+    help="Ignore errors related to mismatch of datatypes: ie: float64 used instead of float32",
+)
+def validate_simulation(config_file, ignore_datatype_errors):
     """Validate Sonata simulation based on config file.
 
     Args:
         config_file (str): path to Sonata simulation config file
+        ignore_datatype_errors (bool): ignore checks related to datatypes
     """
-    simulation_validation.validate(config_file)
+    simulation_validation.validate(config_file, ignore_datatype_errors=ignore_datatype_errors)

--- a/bluepysnap/simulation_validation.py
+++ b/bluepysnap/simulation_validation.py
@@ -491,7 +491,7 @@ def validate_config(config):
     return [error for section in sorted(VALIDATORS) for error in VALIDATORS[section](config)]
 
 
-def validate(config_file, print_errors=True):
+def validate(config_file, print_errors=True, ignore_datatype_errors=False):
     """Validate Sonata simulation config.
 
     Args:
@@ -502,7 +502,7 @@ def validate(config_file, print_errors=True):
         set: set of errors, empty if no errors
     """
     config = _parse_config(config_file)
-    errors = schemas.validate_simulation_schema(config_file, config)
+    errors = schemas.validate_simulation_schema(config_file, config, ignore_datatype_errors)
 
     config = _add_validation_parameters(config, config_file)
     errors += validate_config(config)

--- a/tests/test_schema_validation_simulation.py
+++ b/tests/test_schema_validation_simulation.py
@@ -75,7 +75,7 @@ def _validate(config):
 
     Schema mocked to not have to parse it from file for every validation.
     """
-    return test_module.validate_circuit_schema(CONFIG_FILE, config)
+    return test_module.validate_circuit_schema(CONFIG_FILE, config, ignore_datatype_errors=False)
 
 
 def _remove_from_config(config, to_remove):


### PR DESCRIPTION
* teach the `bluepysnap validate-circuit` and `bluepysnap validate-simulation` the ability to `--ignore-datatype-errors` so that mismatches of datatypes to the specification are ignored