### PR TITLE
Switch to the open-sourced brain-indexer

### DIFF
--- a/bluepysnap/edges/edge_population.py
+++ b/bluepysnap/edges/edge_population.py
@@ -612,15 +612,7 @@ class EdgePopulation:
     @cached_property
     def spatial_synapse_index(self):
         """Access to edges spatial index."""
-        try:
-            from spatial_index import open_index
-        except ImportError as e:
-            raise BluepySnapError(
-                (
-                    "Spatial index is for now only available internally to BBP. "
-                    "It requires `spatial_index`, an internal package."
-                )
-            ) from e
+        from brain_indexer import open_index
 
         index_dir = self._properties.spatial_synapse_index_dir
         if not index_dir:

--- a/bluepysnap/nodes/node_population.py
+++ b/bluepysnap/nodes/node_population.py
@@ -648,15 +648,7 @@ class NodePopulation:
     @cached_property
     def spatial_segment_index(self):
         """Access to edges spatial index."""
-        try:
-            from spatial_index import open_index
-        except ImportError as e:
-            raise BluepySnapError(
-                (
-                    "Spatial index is for now only available internally to BBP. ",
-                    "It requires `spatial_index`, an internal package.",
-                )
-            ) from e
+        from brain_indexer import open_index
 
         index_dir = self._properties.spatial_segment_index_dir
         if not index_dir:

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     name="bluepysnap",
     python_requires=">=3.8",
     install_requires=[
+        "brain-indexer>=3.0.0",
         "cached_property>=1.0",
         "h5py>=3.0.1,<4.0.0",
         "importlib_resources>=5.0.0",
@@ -58,7 +59,6 @@ setup(
     extras_require={
         "docs": ["sphinx", "sphinx-bluebrain-theme"],
         "plots": ["matplotlib>=3.0.0"],
-        "spatial-index": ["spatial-index>=1.2.1"],
     },
     packages=find_packages(),
     package_data={

--- a/tests/test_edge_population.py
+++ b/tests/test_edge_population.py
@@ -728,27 +728,10 @@ class TestEdgePopulation:
     def test_h5_filepath_from_config(self):
         assert self.test_obj.h5_filepath == str(TEST_DATA_DIR / "edges.h5")
 
-    @pytest.mark.skip(reason="Until spatial-index is released publicly")
-    def test_spatial_synapse_index(self):
-        with mock.patch("spatial_index.open_index") as mock_open_index:
-            self.test_obj.spatial_synapse_index
-        mock_open_index.assert_called_once_with("path/to/edge/dir")
-
-    @mock.patch.dict(sys.modules, {"spatial_index": mock.Mock()})
     def test_spatial_synapse_index_call(self):
         with pytest.raises(
             BluepySnapError,
             match="It appears default does not have synapse indices",
-        ):
-            self.test_obj.spatial_synapse_index
-
-    def test_spatial_synapse_index_error(self):
-        with pytest.raises(
-            BluepySnapError,
-            match=(
-                "Spatial index is for now only available internally to BBP. "
-                "It requires `spatial_index`, an internal package."
-            ),
         ):
             self.test_obj.spatial_synapse_index
 
@@ -776,9 +759,9 @@ class TestEdgePopulationSpatialIndex:
             TEST_DATA_DIR / "circuit_config.json", "default2"
         )
 
-    @mock.patch.dict(sys.modules, {"spatial_index": mock.Mock()})
+    @mock.patch.dict(sys.modules, {"brain_indexer": mock.Mock()})
     def test_spatial_synapse_index_call(self):
         self.test_obj.spatial_synapse_index
-        mock = sys.modules["spatial_index"].open_index
+        mock = sys.modules["brain_indexer"].open_index
         assert mock.call_count == 1
         assert mock.call_args[0][0].endswith("path/to/edge/dir")

--- a/tests/test_node_population.py
+++ b/tests/test_node_population.py
@@ -625,23 +625,10 @@ class TestNodePopulation:
     def test_h5_filepath_from_config(self):
         assert self.test_obj.h5_filepath == str(TEST_DATA_DIR / "nodes.h5")
 
-    @pytest.mark.skip(reason="Until spatial-index is released publicly")
-    def test_spatial_segment_index(self):
-        with mock.patch("spatial_index.open_index") as mock_open_index:
-            self.test_obj.spatial_segment_index
-        mock_open_index.assert_called_once_with("path/to/node/dir")
-
-    @mock.patch.dict(sys.modules, {"spatial_index": mock.Mock()})
-    def test_spatial_segment_index_call(self):
-        with pytest.raises(
-            BluepySnapError,
-            match="It appears default does not have segment indices",
-        ):
-            self.test_obj.spatial_segment_index
-
     def test_spatial_segment_index_error(self):
         with pytest.raises(
-            BluepySnapError, match="Spatial index is for now only available internally to BBP."
+            BluepySnapError,
+            match="It appears default does not have segment indices"
         ):
             self.test_obj.spatial_segment_index
 
@@ -718,10 +705,10 @@ class TestNodePopulationSpatialIndex:
     def setup_method(self):
         self.test_obj = Circuit(str(TEST_DATA_DIR / "circuit_config.json")).nodes["default2"]
 
-    @mock.patch.dict(sys.modules, {"spatial_index": mock.Mock()})
+    @mock.patch.dict(sys.modules, {"brain_indexer": mock.Mock()})
     def test_spatial_segment_index_call(self):
         self.test_obj.spatial_segment_index
 
-        mock = sys.modules["spatial_index"].open_index
+        mock = sys.modules["brain_indexer"].open_index
         assert mock.call_count == 1
         assert mock.call_args[0][0].endswith("path/to/node/dir")

--- a/tests/test_node_population.py
+++ b/tests/test_node_population.py
@@ -627,8 +627,7 @@ class TestNodePopulation:
 
     def test_spatial_segment_index_error(self):
         with pytest.raises(
-            BluepySnapError,
-            match="It appears default does not have segment indices"
+            BluepySnapError, match="It appears default does not have segment indices"
         ):
             self.test_obj.spatial_segment_index
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,6 @@ import pickle
 import shutil
 import tempfile
 from contextlib import contextmanager
-from distutils.dir_util import copy_tree
 from pathlib import Path
 
 import numpy.testing as npt
@@ -24,7 +23,7 @@ PICKLED_SIZE_ADJUSTMENT = len(pickle.dumps(str(TEST_DATA_DIR.absolute())))
 
 @contextmanager
 def setup_tempdir(cleanup=True):
-    temp_dir = str(Path(tempfile.mkdtemp()).resolve())
+    temp_dir = Path(tempfile.mkdtemp()).resolve()
     try:
         yield temp_dir
     finally:
@@ -41,7 +40,10 @@ def copy_test_data(config="circuit_config.json"):
         yields a path to the copy of the config file
     """
     with setup_tempdir() as tmp_dir:
-        copy_tree(str(TEST_DATA_DIR), tmp_dir)
+        # shutil.copytree expects the target to not exist
+        if tmp_dir.exists():
+            tmp_dir.rmdir()
+        shutil.copytree(str(TEST_DATA_DIR), tmp_dir)
         copied_path = Path(tmp_dir)
         yield copied_path, copied_path / config
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ name = bluepysnap
 [tox]
 envlist =
     lint
-    py{38,39,310,311}
+    py{39,310,311,312}
 
 ignore_basepython_conflict = true
 


### PR DESCRIPTION
Remove the distutils dependency in the test setup, too.  This module
will not be present any longer in Python 3.12.

Removed tests are duplicated and fail, as spatial indices are only
defined for the second populations of edges and nodes.
